### PR TITLE
Honor `limit` end-to-end in odp_search_applications, shrink fat ODP records (#18)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "patent-mcp-server"
-version = "0.9.0"
+version = "0.9.1"
 description = "Model Context Protocol server for USPTO patent data"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/patent_mcp_server/config.py
+++ b/src/patent_mcp_server/config.py
@@ -36,7 +36,7 @@ class Config:
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
 
     # HTTP Settings
-    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/0.9.0")
+    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/0.9.1")
     REQUEST_TIMEOUT: float = float(os.getenv("REQUEST_TIMEOUT", "30.0"))
 
     # Rate Limiting & Retry

--- a/src/patent_mcp_server/patents.py
+++ b/src/patent_mcp_server/patents.py
@@ -839,6 +839,15 @@ async def odp_search_applications(
     if is_error(result):
         return result
 
+    # Upstream ODP search ignores the `rows` parameter and returns a fixed
+    # page (~25 records). Enforce the caller's `limit` by post-slicing.
+    if isinstance(result, dict) and isinstance(
+        result.get("patentFileWrapperDataBag"), list
+    ):
+        result["patentFileWrapperDataBag"] = (
+            result["patentFileWrapperDataBag"][:limit]
+        )
+
     return check_and_truncate(ResponseEnvelope.from_odp(result, offset, limit))
 
 

--- a/src/patent_mcp_server/util/response.py
+++ b/src/patent_mcp_server/util/response.py
@@ -235,12 +235,33 @@ def estimate_tokens(data: Any) -> int:
         return len(str(data)) // 4
 
 
+# Heavy nested fields stripped from ODP file-wrapper records when slicing alone
+# can't fit the token budget. Listed in priority order — earlier entries are
+# stripped first. Callers can fetch the full record via odp_get_application.
+LEAN_STRIP_FIELDS = (
+    "eventDataBag",
+    "foreignPriorityBag",
+    "assignmentBag",
+    "claims",
+    "descriptionBag",
+)
+
+
 def truncate_response(
     response: Dict[str, Any],
     max_tokens: Optional[int] = None,
     max_results: int = 20,
 ) -> Dict[str, Any]:
     """Truncate a response if it exceeds token budget.
+
+    Two-stage strategy:
+      1. Slice the results list down to ``min(max_results, envelope_limit)``.
+         Honors the user's requested ``limit`` even when fewer than the global
+         default — fixes the case where 20 fat records still bust the budget.
+      2. If still over budget, strip heavy nested fields (eventDataBag,
+         foreignPriorityBag, assignmentBag, claims, descriptionBag) from each
+         record. Records remain visible; stripped fields are replaced with a
+         marker so callers know data was elided.
 
     Args:
         response: Response dictionary to potentially truncate
@@ -257,29 +278,57 @@ def truncate_response(
     if estimated_tokens <= max_tokens:
         return response
 
-    # Need to truncate
     truncated = response.copy()
 
-    # Try to truncate results array
+    # Stage 1: slice results to the effective limit (user request capped by global default).
+    envelope_limit = response.get("limit")
+    effective_max = max_results
+    if isinstance(envelope_limit, int) and envelope_limit > 0:
+        effective_max = min(max_results, envelope_limit)
+
     if "results" in truncated and isinstance(truncated["results"], list):
         original_count = len(truncated["results"])
-        if original_count > max_results:
-            truncated["results"] = truncated["results"][:max_results]
+        if original_count > effective_max:
+            truncated["results"] = truncated["results"][:effective_max]
             truncated["_truncated"] = True
             truncated["_original_count"] = original_count
-            truncated["_truncated_to"] = max_results
+            truncated["_truncated_to"] = effective_max
             truncated["_truncation_message"] = (
-                f"Response truncated from {original_count} to {max_results} results "
+                f"Response truncated from {original_count} to {effective_max} results "
                 f"to fit within token budget. Use 'offset' parameter to paginate "
                 f"through remaining results."
             )
-
-            # Update count
-            truncated["count"] = max_results
+            truncated["count"] = effective_max
 
             logger.info(
-                f"Truncated response from {original_count} to {max_results} results "
+                f"Truncated response from {original_count} to {effective_max} results "
                 f"(estimated {estimated_tokens} tokens exceeded {max_tokens} limit)"
+            )
+
+    # Stage 2: still too big? Strip heavy nested fields per record.
+    if (
+        estimate_tokens(truncated) > max_tokens
+        and isinstance(truncated.get("results"), list)
+    ):
+        stripped_fields: set = set()
+        for record in truncated["results"]:
+            if not isinstance(record, dict):
+                continue
+            for field in LEAN_STRIP_FIELDS:
+                if field in record:
+                    record[field] = {"_stripped": True}
+                    stripped_fields.add(field)
+        if stripped_fields:
+            truncated["_lean_mode"] = True
+            truncated["_stripped_fields"] = sorted(stripped_fields)
+            truncated["_lean_message"] = (
+                "Heavy nested fields stripped to fit token budget. "
+                "Fetch a single application with odp_get_application(app_num) "
+                "to retrieve the full record."
+            )
+            logger.info(
+                f"Stripped fields {sorted(stripped_fields)} from "
+                f"{len(truncated['results'])} record(s) to fit token budget"
             )
 
     return truncated

--- a/test/unit/test_odp_search.py
+++ b/test/unit/test_odp_search.py
@@ -1,0 +1,82 @@
+"""Unit tests for odp_search_applications post-slicing (issue #18)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from patent_mcp_server.patents import odp_search_applications
+
+
+def _fake_upstream_response(num_records: int) -> dict:
+    """Build a fake ODP /applications/search response with N file wrappers."""
+    return {
+        "count": num_records,
+        "patentFileWrapperDataBag": [
+            {
+                "applicationNumberText": f"1612345{i}",
+                "applicationMetaData": {"filingDate": "2020-01-01"},
+                "eventDataBag": [{"event": f"e{i}"}],
+            }
+            for i in range(num_records)
+        ],
+    }
+
+
+@pytest.mark.unit
+async def test_search_post_slices_to_user_limit():
+    """Upstream returns 20 records but caller asked for limit=3 → 3 returned."""
+    upstream = _fake_upstream_response(20)
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=AsyncMock(return_value=upstream),
+    ):
+        result = await odp_search_applications(query="knowledge graph", limit=3)
+
+    assert result["success"] is True
+    assert result["count"] == 3
+    assert len(result["results"]) == 3
+    assert result["limit"] == 3
+    # has_more should reflect that more records exist beyond what we returned.
+    assert result["total"] == 20
+    assert result["has_more"] is True
+
+
+@pytest.mark.unit
+async def test_search_passes_through_when_upstream_under_limit():
+    """If upstream already returns ≤ limit, no slicing changes anything."""
+    upstream = _fake_upstream_response(2)
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=AsyncMock(return_value=upstream),
+    ):
+        result = await odp_search_applications(query="anything", limit=10)
+
+    assert result["count"] == 2
+    assert len(result["results"]) == 2
+
+
+@pytest.mark.unit
+async def test_search_propagates_upstream_error():
+    """When the API client returns an error dict, we don't try to slice it."""
+    error = {"error": True, "message": "boom", "error_code": "HTTP_500"}
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=AsyncMock(return_value=error),
+    ):
+        result = await odp_search_applications(query="anything", limit=3)
+
+    assert result == error
+
+
+@pytest.mark.unit
+async def test_search_handles_empty_databag():
+    """No patentFileWrapperDataBag in response shouldn't crash."""
+    upstream = {"count": 0}
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=AsyncMock(return_value=upstream),
+    ):
+        result = await odp_search_applications(query="nothing", limit=3)
+
+    # Without the bag, from_odp falls through to the "direct data" branch.
+    assert result["success"] is True

--- a/test/unit/test_response_util.py
+++ b/test/unit/test_response_util.py
@@ -1,0 +1,123 @@
+"""Unit tests for response truncation utilities (issue #18)."""
+
+import pytest
+
+from patent_mcp_server.config import config
+from patent_mcp_server.util.response import (
+    LEAN_STRIP_FIELDS,
+    ResponseEnvelope,
+    check_and_truncate,
+    truncate_response,
+)
+
+
+def _fat_record(size_chars: int = 12_000) -> dict:
+    """Build a fake ODP file-wrapper record with a large eventDataBag."""
+    payload = "x" * size_chars
+    return {
+        "applicationNumberText": "16123456",
+        "applicationMetaData": {"filingDate": "2020-01-01"},
+        "eventDataBag": [{"event": payload}],
+        "foreignPriorityBag": [{"country": "JP", "filing": payload[:1000]}],
+    }
+
+
+@pytest.mark.unit
+def test_truncate_no_op_under_budget():
+    """Small responses pass through unchanged."""
+    response = ResponseEnvelope.success(
+        results=[{"id": 1}], source="odp", offset=0, limit=10
+    )
+    out = truncate_response(response, max_tokens=10_000)
+    assert out is response
+    assert "_truncated" not in out
+    assert "_lean_mode" not in out
+
+
+@pytest.mark.unit
+def test_truncate_respects_envelope_limit():
+    """When envelope.limit is smaller than max_results, slice to limit."""
+    fat_records = [_fat_record(2_000) for _ in range(20)]
+    response = ResponseEnvelope.success(
+        results=fat_records, source="odp", total=18_000, offset=0, limit=3
+    )
+    # Force truncation by setting a tiny budget.
+    out = truncate_response(response, max_tokens=500, max_results=20)
+    assert out["_truncated"] is True
+    assert out["_truncated_to"] == 3  # min(20, envelope.limit=3)
+    assert out["_original_count"] == 20
+    assert out["count"] == 3
+    assert len(out["results"]) == 3
+
+
+@pytest.mark.unit
+def test_truncate_uses_max_results_when_no_envelope_limit():
+    """When envelope.limit isn't a positive int, fall back to max_results."""
+    response = {
+        "success": True,
+        "source": "odp",
+        "results": [{"id": i} for i in range(50)],
+        "count": 50,
+    }  # No `limit` key.
+    out = truncate_response(response, max_tokens=100, max_results=5)
+    assert out["_truncated"] is True
+    assert out["_truncated_to"] == 5
+    assert len(out["results"]) == 5
+
+
+@pytest.mark.unit
+def test_truncate_strips_heavy_fields_when_slice_insufficient():
+    """If post-slice payload still exceeds budget, strip nested heavy fields."""
+    # 3 fat records — slicing alone (limit=3) won't shrink count, so stripping
+    # is required to fit a small token budget.
+    fat_records = [_fat_record(50_000) for _ in range(3)]
+    response = ResponseEnvelope.success(
+        results=fat_records, source="odp", total=3, offset=0, limit=3
+    )
+    out = truncate_response(response, max_tokens=500, max_results=20)
+
+    assert len(out["results"]) == 3  # records preserved
+    assert out["_lean_mode"] is True
+    assert "eventDataBag" in out["_stripped_fields"]
+    for record in out["results"]:
+        assert record["eventDataBag"] == {"_stripped": True}
+        # Non-heavy fields preserved.
+        assert "applicationNumberText" in record
+
+
+@pytest.mark.unit
+def test_truncate_disabled_via_config(monkeypatch):
+    """check_and_truncate respects TRUNCATE_LARGE_RESPONSES=False."""
+    monkeypatch.setattr(config, "TRUNCATE_LARGE_RESPONSES", False)
+    fat_records = [_fat_record(50_000) for _ in range(20)]
+    response = ResponseEnvelope.success(
+        results=fat_records, source="odp", total=20, offset=0, limit=3
+    )
+    out = check_and_truncate(response)
+    assert out is response
+    assert "_truncated" not in out
+    assert "_lean_mode" not in out
+
+
+@pytest.mark.unit
+def test_lean_strip_fields_includes_event_data_bag():
+    """Sanity check: the configured strip list covers the issue's offenders."""
+    expected = {
+        "eventDataBag",
+        "foreignPriorityBag",
+        "assignmentBag",
+        "claims",
+        "descriptionBag",
+    }
+    assert expected.issubset(set(LEAN_STRIP_FIELDS))
+
+
+@pytest.mark.unit
+def test_check_and_truncate_passes_through_when_under_budget(monkeypatch):
+    """Small responses are returned unchanged through check_and_truncate."""
+    monkeypatch.setattr(config, "TRUNCATE_LARGE_RESPONSES", True)
+    response = ResponseEnvelope.success(
+        results=[{"id": 1}], source="odp", offset=0, limit=10
+    )
+    out = check_and_truncate(response)
+    assert out is response

--- a/uv.lock
+++ b/uv.lock
@@ -796,7 +796,7 @@ wheels = [
 
 [[package]]
 name = "patent-mcp-server"
-version = "0.8.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "h2" },


### PR DESCRIPTION
The ODP /applications/search endpoint ignores the `rows` query parameter and
always returns its default page (~25 records), so callers passing limit=3
got 20 full file-wrapper records (~770 KB / ~190K tokens). The truncator
also only sliced the result count, never per-record size, so it could not
recover when records were individually huge.

Fixes:

1. odp_search_applications now post-slices patentFileWrapperDataBag to the
   user-requested limit before constructing the response envelope.

2. truncate_response now (a) caps results at min(max_results, envelope.limit)
   so a small user limit is enforced even when the global default is larger,
   and (b) when slicing alone still exceeds the token budget, strips heavy
   nested fields (eventDataBag, foreignPriorityBag, assignmentBag, claims,
   descriptionBag) per record and marks them with {"_stripped": True} so
   callers know to fetch the full record via odp_get_application.

Added unit tests for both code paths. Version bumped to 0.9.1.