### PR TITLE
Fix #21: honor PPUBS query + ODP filters; add contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,110 @@
+name: Bug report
+description: Report a tool that returns incorrect or unexpected results
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The most useful reports include the **exact tool call** and the **constructed request** (URL/body) the client built — see [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
+
+        If you're an AI agent, please also read [AGENTS.md](../AGENTS.md).
+
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Affected tool
+      description: Which MCP tool is misbehaving?
+      options:
+        - ppubs_search_patents
+        - ppubs_search_applications
+        - ppubs_get_full_document
+        - ppubs_get_patent_by_number
+        - ppubs_download_patent_pdf
+        - odp_search_applications
+        - odp_search_datasets
+        - odp_get_application
+        - odp_get_application_metadata
+        - odp_get_continuity
+        - odp_get_assignment
+        - odp_get_adjustment
+        - odp_get_attorney
+        - odp_get_foreign_priority
+        - odp_get_transactions
+        - odp_get_documents
+        - odp_get_dataset
+        - get_cpc_info
+        - get_status_code
+        - check_api_status
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: call
+    attributes:
+      label: Exact tool call
+      description: Copy-paste the tool name and the arguments you passed.
+      placeholder: |
+        ppubs_search_patents(query="machine learning", limit=25)
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: One sentence on what you expected.
+      placeholder: Top results should mention machine learning in the title or abstract.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: One sentence on what actually happened. Include sample output if short.
+      placeholder: Results were the latest 25 grants regardless of query — same hits for "machine learning", "quantum cryptography", and "solar panel".
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: Constructed request (LOG_LEVEL=DEBUG)
+      description: |
+        Re-run with `LOG_LEVEL=DEBUG` and paste the URL and (for POST) the request body the client logged. This is the single highest-value field — it usually pins the bug down immediately.
+      placeholder: |
+        POST https://api.uspto.gov/api/v1/patent/applications/search
+        body: {"q": "applicationMetaData.firstApplicantName:\"IBM\"", "pagination": {"offset":0, "limit":5}}
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: response
+    attributes:
+      label: Raw upstream response (optional, but very useful)
+      description: First ~50 lines of the raw response from the USPTO API when relevant. Trim or redact as needed.
+      render: json
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `pip show patent-mcp-server` or the version you installed.
+      placeholder: "0.9.4"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: not-decommissioned
+    attributes:
+      label: Confirmation
+      description: ""
+      options:
+        - label: I checked the [README](../README.md) and the affected tool is **not** one of the APIs that was decommissioned (PatentsView, PTAB on ODP, Litigation on ODP, Office Actions, Enriched Citations). Decommissioned tools intentionally return `API_UNAVAILABLE`.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/riemannzeta/patent_mcp_server/blob/main/CONTRIBUTING.md
+    about: How to file a good issue, branch + commit conventions, project rules.
+  - name: AGENTS.md (for AI agent contributors)
+    url: https://github.com/riemannzeta/patent_mcp_server/blob/main/AGENTS.md
+    about: Specific guidance for AI agents filing issues or PRs.
+  - name: API status check
+    url: https://github.com/riemannzeta/patent_mcp_server/blob/main/README.md
+    about: PatentsView, PTAB-on-ODP, Litigation-on-ODP, Office Actions, and Enriched Citations are intentionally `API_UNAVAILABLE`. Check before filing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest a new tool, parameter, or capability
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please be specific about which USPTO data source backs the feature — we can only build what an upstream API actually exposes.
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: Data source
+      description: Which USPTO data source would back this feature?
+      options:
+        - PPUBS (ppubs.uspto.gov, full text + PDFs)
+        - ODP (api.uspto.gov, metadata + prosecution)
+        - USPTO bulk datasets
+        - Not sure / multiple
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to do with patent data, and where does the current tool set fall short?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed tool / parameter shape
+      description: If you have a specific tool signature in mind, sketch it here. Otherwise just describe the desired behavior.
+      placeholder: |
+        odp_search_applications(..., assignee_name_fuzzy=True, ...)
+        # Returns approximate-match results instead of exact term-match on firstApplicantName.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: upstream
+    attributes:
+      label: Relevant upstream API endpoint (if known)
+      description: Link to the USPTO API docs or Swagger entry that would back this.
+      placeholder: https://data.uspto.gov/...
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for the PR. Keep this short — one summary, one test plan, one issue link.
+Full guidelines: CONTRIBUTING.md and AGENTS.md (for AI-agent contributors).
+-->
+
+## Summary
+
+<!-- One or two sentences. What changed, why. -->
+
+## Linked issue
+
+Closes #<!-- issue number -->
+
+## Test plan
+
+- [ ] `uv run pytest` passes (all unit tests green)
+- [ ] New behavior is covered by a new unit test
+- [ ] Tested manually against the live USPTO API (if applicable) — describe how below
+
+<!-- Notes on manual / integration testing: -->
+
+## Checklist
+
+- [ ] Docstrings updated (especially `USE THIS TOOL WHEN:` and `Args:` for tool definitions)
+- [ ] Version bumped in `pyproject.toml` AND `src/patent_mcp_server/config.py` (`USER_AGENT`) if user-visible
+- [ ] If touching a decommissioned API: followed the 7-step pattern in [CLAUDE.md](../CLAUDE.md)
+- [ ] No new dependencies (or, if added, justified in the description)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+Guidance for AI agents (Claude, GPT-class, Cursor, Aider, etc.) contributing issues, PRs, or code review to `patent-mcp-server`.
+
+This file complements [CONTRIBUTING.md](CONTRIBUTING.md), which applies to all contributors. Read both.
+
+## Read CLAUDE.md first
+
+[`CLAUDE.md`](CLAUDE.md) is the authoritative source for project conventions: release workflow, tool naming, error handling, the decommissioned-API pattern, and the rule that all unit tests must pass before any commit. **An agent that hasn't read CLAUDE.md will get patterns subtly wrong** — read it before making changes.
+
+## When filing an issue
+
+Use the bug-report or feature-request template (`.github/ISSUE_TEMPLATE/`). Both are YAML forms — fill in every required field.
+
+The single highest-value thing you can include is the **constructed request** the client made, captured from `LOG_LEVEL=DEBUG`. Many "the tool returns wrong results" reports turn out to be either user-side query syntax or upstream USPTO API quirks; the logged URL and body settle it instantly.
+
+If you don't have access to live logs (for example, the user reported the bug to you secondhand), say so explicitly in the report — write "constructed request not captured" rather than guessing or omitting. A report that admits a gap is more useful than one that papers over it.
+
+Don't file an issue for a tool that returns `API_UNAVAILABLE` — those are intentional and documented. Check `check_api_status` first.
+
+## When submitting a PR
+
+In order:
+
+1. **Confirm the bug exists.** Reproduce it locally — either via `uv run pytest -m integration` or by writing a one-off async script that hits the affected tool. A PR without reproduction is a guess.
+2. **Identify the root cause.** Don't pattern-match a fix to surface symptoms. If a query parameter is being ignored, find *why* — wrong default, dropped param, upstream API requiring a different shape, etc.
+3. **Write a unit test that fails before the fix and passes after.** This is the contract that prevents regression.
+4. **Make the smallest fix that addresses the root cause.** Don't refactor adjacent code in the same PR unless it's necessary for the fix.
+5. **Run the full test suite.** `uv run pytest` — must be 100% green.
+6. **Bump the version** if the change is user-visible. Patch in both `pyproject.toml` and `config.py:USER_AGENT`.
+7. **Update docstrings.** The `Args:` and `USE THIS TOOL WHEN:` sections in tool definitions are surfaced to other LLMs as the tool's interface — they matter as much as the code.
+
+Branch name convention for agent-authored PRs: `claude/<slug>`, `aider/<slug>`, etc. — any prefix that identifies the agent is fine.
+
+## Project layout cheat sheet
+
+```
+src/patent_mcp_server/
+├── patents.py              # MCP tool definitions (the public surface)
+├── config.py               # Env-var-driven config; bump USER_AGENT here on release
+├── uspto/
+│   ├── ppubs_uspto_gov.py  # Patent Public Search client (PPUBS)
+│   └── api_uspto_gov.py    # Open Data Portal client (ODP)
+├── util/{errors,response,validation,logging}.py
+└── json/search_query.json  # PPUBS request template
+test/unit/                  # Network-free, run by default
+test/test_tools*.py         # Integration tests, network required, opt-in via -m integration
+```
+
+## Conventions in one screen
+
+- **Tool naming**: `ppubs_*`, `odp_*`, `ptab_*`, `patentsview_*` (legacy).
+- **Parameters**: `query` not `q`; `app_num`; `patent_number`; `offset` + `limit`.
+- **Error returns**: `{"error": True, "message": ..., "error_code": ...}` — build via `ApiError.create()`.
+- **Decommissioned APIs** return `error_code="API_UNAVAILABLE"` with a `workaround` field pointing at the active replacement.
+- **Everything is async.** Tool functions are `async def`; clients use `async with`.
+- **No new dependencies** without a clear reason. The existing four cover almost everything.
+
+## What not to do
+
+- Don't restructure the package layout to "modernize" it. Single `patents.py` for tool definitions is intentional — MCP servers benefit from one obvious entry point.
+- Don't add abstractions ("BaseClient", "ToolRegistry", dependency injection) without an explicit ask. The codebase deliberately prefers shallow, readable code.
+- Don't delete or rename a tool that's been published, even if it returns `API_UNAVAILABLE`. MCP clients may be pinned to the name.
+- Don't skip tests to make a commit go through. If a test fails, fix the root cause.
+- Don't commit the `.env` file or any secrets. Check `git status` before every commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+Thanks for taking the time to improve `patent-mcp-server`. This project is small, the surface area is well-defined, and clear contributions are easy to land. AI agents are explicit first-class contributors — see [AGENTS.md](AGENTS.md) for agent-specific guidance and the issue templates that follow.
+
+## Quick start
+
+```bash
+git clone https://github.com/riemannzeta/patent_mcp_server.git
+cd patent_mcp_server
+uv sync --dev
+cp .env.example .env  # then fill in USPTO_API_KEY
+uv run pytest         # ~259 unit tests should pass
+```
+
+Integration tests (which hit the live USPTO APIs) are skipped by default; run them with `uv run pytest -m integration`. They require a valid `USPTO_API_KEY` and outbound network access to `api.uspto.gov` and `ppubs.uspto.gov`.
+
+## Filing a good bug report
+
+Most of the time spent on a bug report is reproducing it. Help us skip that step.
+
+The `.github/ISSUE_TEMPLATE/bug_report.yml` template prompts for everything we need, but the gist:
+
+- **Exact tool call** — the tool name and the arguments you passed, copy-pasted. Example: `ppubs_search_patents(query="machine learning", limit=25)`.
+- **Expected vs actual** — one sentence each. "Expected the top results to mention machine learning; actually got the latest grants regardless of query."
+- **Constructed request** — set `LOG_LEVEL=DEBUG` in your env, re-run, and paste the URL and (for POST) the request body the client logged. This is usually the difference between "we'll get to it" and "I see the bug, here's the fix."
+- **Raw upstream response** — first ~50 lines of the raw API response when relevant. If you don't have it, that's fine, but it usually pins down whether the bug is in our code or upstream at USPTO.
+- **Version** — output of `pip show patent-mcp-server` or the installed PyPI version.
+- **Whether the affected tool is one of the [decommissioned APIs](README.md)** — if so, the tool is intentionally returning `API_UNAVAILABLE`; that's not a bug.
+
+A weak report ("ppubs search returns wrong results") will get triaged but probably stall. A report with the four bullets above usually gets a fix in the same session.
+
+## Filing a good PR
+
+Before opening a PR:
+
+1. **All tests pass** — `uv run pytest` must be green. No skipping tests to make a PR mergeable.
+2. **New behavior has new tests** — unit tests live under `test/unit/` and mock the network. Integration tests live in `test/test_tools.py` / `test/test_tools_pytest.py` and run against the live USPTO APIs.
+3. **Docstrings updated** — especially the `USE THIS TOOL WHEN:` and `Args:` sections, since these are surfaced to MCP clients and LLMs.
+4. **Version bumped if user-visible** — patch bump in both `pyproject.toml` AND `src/patent_mcp_server/config.py` (`USER_AGENT`). See [`CLAUDE.md`](CLAUDE.md) for the full release workflow.
+5. **Touched a decommissioned API?** Follow the seven-step pattern documented in [`CLAUDE.md`](CLAUDE.md) → "Handling Decommissioned APIs."
+
+PR conventions:
+
+- **Branch naming**: `fix/<issue-or-slug>`, `feature/<slug>`, `docs/<slug>`. AI-agent branches commonly use `claude/<slug>` — that's fine.
+- **Commit messages**: short imperative subject (≤72 chars), optional body explaining *why* the change is needed. Match the style of recent commits on `main`.
+- **Co-authored commits from AI agents are welcome** — add the standard `Co-Authored-By:` trailer.
+- The PR template prompts for a one-line summary, the test plan, and a link to the issue.
+
+## Project conventions
+
+This summary is intentionally short — the source of truth is [`CLAUDE.md`](CLAUDE.md).
+
+- **Tool naming**: `ppubs_*`, `odp_*`, `ptab_*`, `patentsview_*` — match the API source.
+- **Parameter naming**: `query` (not `q`), `app_num`, `patent_number`, `offset`, `limit`.
+- **Error shape**: every tool returns either `{"success": True, "results": ...}` or `{"error": True, "message": ..., "error_code": ...}`. Use `ApiError.create()` to build errors.
+- **Async everywhere**: all clients are async, all tools are `async def`.
+- **Don't introduce new dependencies without a clear reason.** `httpx`, `pydantic`, `tenacity`, `mcp[cli]` cover almost everything.
+
+## Code of conduct
+
+Be kind, assume good faith, keep discussions technical. Disagreements are normal; personal attacks are not.

--- a/README.md
+++ b/README.md
@@ -303,9 +303,20 @@ rm -rf dist/ && uv run python -m build
 uv run twine upload dist/*
 ```
 
+## Contributing
+
+Issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution guide, and [AGENTS.md](AGENTS.md) for guidance specific to AI agents. Use the [bug report](.github/ISSUE_TEMPLATE/bug_report.yml) or [feature request](.github/ISSUE_TEMPLATE/feature_request.yml) templates when filing an issue — they prompt for the tool call, the constructed request URL/body, and the raw API response, which is usually enough to land a fix in one turn.
+
 ## Version History
 
-### v0.9.0 (Current)
+### v0.9.4 (Current)
+- Fix `ppubs_search_patents` / `ppubs_search_applications` query semantics ([issue #21](https://github.com/riemannzeta/patent_mcp_server/issues/21)): default operator changed from `OR` to `AND`, so multi-word queries like `machine learning` no longer match the entire corpus and collapse into the latest-grants fallback under `date_publ desc` sort.
+- Fix template-mutation bug in PPUBS client (`search_query.copy()` → `copy.deepcopy(...)`), eliminating a concurrency hazard between parallel calls.
+- Fix `odp_search_applications` filters being silently ignored upstream ([issue #21](https://github.com/riemannzeta/patent_mcp_server/issues/21)): switched from GET query-string params to POST with a Lucene-style `q` body. `assignee_name`, `inventor_name`, `application_number`, `patent_number`, and filing-date ranges are now properly AND-combined into the search. Tool now returns `MISSING_FILTER` rather than dumping the full 12.8M-record corpus when called with no filters.
+- Updated `ppubs_search_patents` / `ppubs_search_applications` / `odp_search_applications` docstrings to reflect the corrected semantics and document Lucene query support on ODP.
+- Added `CONTRIBUTING.md`, `AGENTS.md`, bug-report + feature-request issue templates, and a PR template.
+
+### v0.9.0
 - Handle PTAB Trial API and Patent Litigation API unavailability on ODP ([issue #16](https://github.com/riemannzeta/patent_mcp_server/issues/16))
 - All 7 `ptab_*` tools and 4 litigation tools now return `API_UNAVAILABLE` with workaround guidance pointing to PPUBS tools and USPTO bulk datasets
 - Active tool count: 20 (down from 31); unavailable: 32 (up from 21); total registered remains 52

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "patent-mcp-server"
-version = "0.9.3"
+version = "0.9.4"
 description = "Model Context Protocol server for USPTO patent data"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/patent_mcp_server/config.py
+++ b/src/patent_mcp_server/config.py
@@ -36,7 +36,7 @@ class Config:
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
 
     # HTTP Settings
-    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/0.9.3")
+    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/0.9.4")
     REQUEST_TIMEOUT: float = float(os.getenv("REQUEST_TIMEOUT", "30.0"))
 
     # Rate Limiting & Retry

--- a/src/patent_mcp_server/patents.py
+++ b/src/patent_mcp_server/patents.py
@@ -437,11 +437,17 @@ async def ppubs_search_patents(
     (PPUBS updates daily vs PatentsView periodic updates).
 
     Args:
-        query: Search query using USPTO syntax. Examples:
-               - "machine learning" - searches all fields
+        query: Search query using USPTO BRS syntax. Multi-word terms are
+               AND-ed across all fields by default — quote phrases that
+               must appear together. Examples:
+               - '"machine learning"' - exact phrase, all fields
+               - machine learning - both terms anywhere (AND)
                - TTL/"neural network" - title contains phrase
                - IN/Smith AND AN/IBM - inventor Smith, assignee IBM
                - CPC/G06N3/08 - CPC classification
+               Default `sort="date_publ desc"` means broad queries return
+               the latest grants first — narrow with field qualifiers
+               (TTL/, AB/, IN/, AN/, CPC/) to get relevant matches.
         offset: Starting position for pagination (default: 0)
         limit: Maximum results to return (default: 100, max: 500)
         sort: Sort order (default: "date_publ desc")
@@ -478,7 +484,10 @@ async def ppubs_search_applications(
     (applications publish 18 months after filing, before grant).
 
     Args:
-        query: Search query using USPTO syntax (same as ppubs_search_patents)
+        query: Search query using USPTO BRS syntax (same as
+               ppubs_search_patents). Multi-word terms are AND-ed —
+               quote phrases that must appear together (e.g.
+               '"machine learning"').
         offset: Starting position for pagination (default: 0)
         limit: Maximum results to return (default: 100, max: 500)
         sort: Sort order (default: "date_publ desc")
@@ -799,14 +808,18 @@ async def odp_search_applications(
     USE THIS TOOL WHEN: You need to search applications with filtering
     by applicant metadata, dates, or other criteria not available in PPUBS.
 
-    Supports both simple queries and complex multi-field filtering.
+    Supports both free-text queries and structured multi-field filtering.
+    Typed filters are AND-ed together; pass a Lucene-style string in
+    `query` for OR or more complex expressions.
 
     Args:
-        query: General search query string
-        application_number: Filter by application number
-        patent_number: Filter by patent number
-        inventor_name: Filter by inventor name
-        assignee_name: Filter by assignee/applicant name
+        query: Free-text or Lucene-style query (e.g. 'neural network',
+               'applicationMetaData.firstInventorName:Smith OR
+               applicationMetaData.firstInventorName:Jones')
+        application_number: Filter by application number (exact match)
+        patent_number: Filter by patent number (exact match)
+        inventor_name: Filter by inventor name (matches first inventor)
+        assignee_name: Filter by applicant/assignee name (matches first applicant)
         filing_date_from: Filing date range start (YYYY-MM-DD)
         filing_date_to: Filing date range end (YYYY-MM-DD)
         offset: Starting position (default: 0)
@@ -815,32 +828,56 @@ async def odp_search_applications(
     Returns:
         Normalized response with matching applications.
     """
-    params = {"start": offset, "rows": limit}
+    clauses: List[str] = []
+
+    def _quote(value: str) -> str:
+        # Lucene-safe quoted value: escape embedded quotes and backslashes.
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
 
     if query:
-        params["q"] = query
+        # Pass user query through verbatim — supports Lucene operators.
+        clauses.append(f"({query})")
     if application_number:
-        params["applicationNumberText"] = application_number
+        clauses.append(f"applicationNumberText:{_quote(application_number)}")
     if patent_number:
-        params["patentNumber"] = patent_number
+        clauses.append(f"applicationMetaData.patentNumber:{_quote(patent_number)}")
     if inventor_name:
-        params["inventorName"] = inventor_name
+        clauses.append(
+            f"applicationMetaData.firstInventorName:{_quote(inventor_name)}"
+        )
     if assignee_name:
-        params["assigneeName"] = assignee_name
+        clauses.append(
+            f"applicationMetaData.firstApplicantName:{_quote(assignee_name)}"
+        )
     if filing_date_from or filing_date_to:
-        date_range = f"{filing_date_from or '*'},{filing_date_to or '*'}"
-        params["appFilingDate"] = date_range
+        start = filing_date_from or "*"
+        end = filing_date_to or "*"
+        clauses.append(f"applicationMetaData.filingDate:[{start} TO {end}]")
 
-    query_string = api_client.build_query_string(params)
-    url = f"{config.API_BASE_URL}/api/v1/patent/applications/search?{query_string}"
+    if not clauses:
+        return ApiError.create(
+            message=(
+                "At least one filter is required. Provide query, "
+                "application_number, patent_number, inventor_name, "
+                "assignee_name, or a filing_date range."
+            ),
+            error_code="MISSING_FILTER",
+        )
 
-    result = await api_client.make_request(url)
+    lucene_query = " AND ".join(clauses)
+    body = {
+        "q": lucene_query,
+        "pagination": {"offset": offset, "limit": limit},
+    }
+
+    url = f"{config.API_BASE_URL}/api/v1/patent/applications/search"
+    result = await api_client.make_request(url, method="POST", data=body)
 
     if is_error(result):
         return result
 
-    # Upstream ODP search ignores the `rows` parameter and returns a fixed
-    # page (~25 records). Enforce the caller's `limit` by post-slicing.
+    # Defensive slice in case upstream returns more than requested.
     if isinstance(result, dict) and isinstance(
         result.get("patentFileWrapperDataBag"), list
     ):

--- a/src/patent_mcp_server/uspto/ppubs_uspto_gov.py
+++ b/src/patent_mcp_server/uspto/ppubs_uspto_gov.py
@@ -6,6 +6,7 @@ which provides full text patent documents, patent PDFs, and advanced search capa
 """
 
 import os
+import copy
 import json
 import asyncio
 from typing import Any, Optional, Dict, List, Union
@@ -199,7 +200,7 @@ class PpubsClient:
         start: int = Defaults.SEARCH_START,
         limit: int = Defaults.SEARCH_LIMIT,
         sort: str = "date_publ desc",
-        default_operator: str = "OR",
+        default_operator: str = "AND",
         sources: List[str] = None,
         expand_plurals: bool = True,
         british_equivalents: bool = True,
@@ -229,8 +230,9 @@ class PpubsClient:
 
         logger.info(f"Running query: {query}")
 
-        # Prepare query data
-        data = self.search_query.copy()
+        # Deep copy so nested mutations below don't bleed into self.search_query
+        # (concurrent calls would otherwise share data["query"] state).
+        data = copy.deepcopy(self.search_query)
         data["start"] = start
         data["pageCount"] = min(limit, Defaults.SEARCH_LIMIT_MAX)
         data["sort"] = sort

--- a/test/unit/test_odp_search.py
+++ b/test/unit/test_odp_search.py
@@ -1,4 +1,10 @@
-"""Unit tests for odp_search_applications post-slicing (issue #18)."""
+"""Unit tests for odp_search_applications.
+
+Covers:
+- Post-slicing to honor user limit (issue #18).
+- Lucene-`q` POST request shape for assignee/inventor/date/etc. filters
+  (issue #21 — the GET query-string filters were silently dropped upstream).
+"""
 
 from unittest.mock import AsyncMock, patch
 
@@ -80,3 +86,104 @@ async def test_search_handles_empty_databag():
 
     # Without the bag, from_odp falls through to the "direct data" branch.
     assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #21: filters must be sent in a Lucene `q` POST body, not GET params.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+async def test_assignee_filter_sent_as_lucene_post():
+    """assignee_name must produce a POST with a Lucene clause on
+    applicationMetaData.firstApplicantName (issue #21)."""
+    mock_request = AsyncMock(return_value=_fake_upstream_response(0))
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=mock_request,
+    ):
+        await odp_search_applications(assignee_name="IBM", limit=5)
+
+    args, kwargs = mock_request.call_args
+    assert kwargs.get("method") == "POST"
+    body = kwargs.get("data")
+    assert body is not None
+    assert 'applicationMetaData.firstApplicantName:"IBM"' in body["q"]
+    assert body["pagination"] == {"offset": 0, "limit": 5}
+
+
+@pytest.mark.unit
+async def test_multiple_filters_are_ANDed_in_q():
+    """Multiple typed filters must be AND-ed in the Lucene `q` string."""
+    mock_request = AsyncMock(return_value=_fake_upstream_response(0))
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=mock_request,
+    ):
+        await odp_search_applications(
+            assignee_name="NVIDIA Corporation",
+            inventor_name="Smith",
+            filing_date_from="2024-01-01",
+            filing_date_to="2024-12-31",
+            limit=5,
+        )
+
+    body = mock_request.call_args.kwargs["data"]
+    q = body["q"]
+    assert ' AND ' in q
+    assert 'applicationMetaData.firstApplicantName:"NVIDIA Corporation"' in q
+    assert 'applicationMetaData.firstInventorName:"Smith"' in q
+    assert 'applicationMetaData.filingDate:[2024-01-01 TO 2024-12-31]' in q
+
+
+@pytest.mark.unit
+async def test_free_text_query_is_wrapped_and_combined():
+    """A free-text `query` should be parenthesised and AND-combined with
+    typed filters so it doesn't accidentally bind to the wrong clause."""
+    mock_request = AsyncMock(return_value=_fake_upstream_response(0))
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=mock_request,
+    ):
+        await odp_search_applications(
+            query="neural network",
+            assignee_name="IBM",
+            limit=5,
+        )
+
+    q = mock_request.call_args.kwargs["data"]["q"]
+    assert "(neural network)" in q
+    assert 'applicationMetaData.firstApplicantName:"IBM"' in q
+    assert ' AND ' in q
+
+
+@pytest.mark.unit
+async def test_quotes_in_value_are_escaped():
+    """Embedded quotes in a filter value must be escaped, not break the
+    Lucene query."""
+    mock_request = AsyncMock(return_value=_fake_upstream_response(0))
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=mock_request,
+    ):
+        await odp_search_applications(assignee_name='ACME "BIG" CORP', limit=5)
+
+    q = mock_request.call_args.kwargs["data"]["q"]
+    # Embedded quotes must be backslash-escaped inside the surrounding quotes.
+    assert r'applicationMetaData.firstApplicantName:"ACME \"BIG\" CORP"' in q
+
+
+@pytest.mark.unit
+async def test_no_filters_returns_missing_filter_error():
+    """Without any filter we'd dump the entire 12.8M-record corpus, so the
+    tool must refuse (issue #21)."""
+    mock_request = AsyncMock(return_value=_fake_upstream_response(0))
+    with patch(
+        "patent_mcp_server.patents.api_client.make_request",
+        new=mock_request,
+    ):
+        result = await odp_search_applications()
+
+    assert result.get("error") is True
+    assert result.get("error_code") == "MISSING_FILTER"
+    # And we must not have called upstream.
+    mock_request.assert_not_called()

--- a/test/unit/test_ppubs_client.py
+++ b/test/unit/test_ppubs_client.py
@@ -466,3 +466,58 @@ async def test_context_manager_cleanup():
             pass
 
     # Context manager should trigger cleanup
+
+
+# ============================================================================
+# Issue #21: query operator + template isolation
+# ============================================================================
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_query_defaults_to_AND_operator(ppubs_client):
+    """Default operator is AND so multi-word queries don't OR-fan-out
+    into the latest-grants fallback (issue #21)."""
+    ppubs_client.case_id = "case-1"
+    ppubs_client.session_expires_at = datetime.now() + timedelta(minutes=30)
+
+    posted_bodies = []
+
+    async def capture_request(method, url, **kwargs):
+        posted_bodies.append(kwargs.get("json"))
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = MOCK_SEARCH_RESPONSE
+        resp.get.return_value = False
+        return resp
+
+    with patch.object(ppubs_client, "make_request", side_effect=capture_request):
+        await ppubs_client.run_query(query="machine learning")
+
+    # First call posts the inner query (counts endpoint); second posts the wrapper.
+    counts_body, search_body = posted_bodies
+    assert counts_body["op"] == "AND"
+    assert search_body["query"]["op"] == "AND"
+    assert counts_body["q"] == "machine learning"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_query_does_not_mutate_template(ppubs_client):
+    """Two sequential calls with different queries must not see each other's
+    state — the template was previously shared via shallow copy (issue #21)."""
+    ppubs_client.case_id = "case-1"
+    ppubs_client.session_expires_at = datetime.now() + timedelta(minutes=30)
+
+    template_q_before = ppubs_client.search_query["query"]["q"]
+
+    async def fake_request(method, url, **kwargs):
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = MOCK_SEARCH_RESPONSE
+        resp.get.return_value = False
+        return resp
+
+    with patch.object(ppubs_client, "make_request", side_effect=fake_request):
+        await ppubs_client.run_query(query="first query")
+        await ppubs_client.run_query(query="second query")
+
+    # Template must still hold its original q after both calls.
+    assert ppubs_client.search_query["query"]["q"] == template_q_before

--- a/uv.lock
+++ b/uv.lock
@@ -805,7 +805,7 @@ wheels = [
 
 [[package]]
 name = "patent-mcp-server"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "h2" },


### PR DESCRIPTION
PPUBS (ppubs_search_patents / ppubs_search_applications):
- Default operator changed from OR to AND. Unquoted multi-word queries like "machine learning" previously fanned out into "machine OR learning", matching almost the entire corpus and collapsing into the latest-grants fallback under sort=date_publ desc.
- Replaced shallow copy of the search-query template with deepcopy so concurrent runs no longer share mutable nested state.
- Updated tool docstrings to recommend quoted phrases and explain that broad queries surface the latest grants by sort default.

ODP (odp_search_applications):
- Filters (assignee_name, inventor_name, patent_number, application_number, filing-date range) were sent as GET query-string params and silently dropped upstream — IBM and Microsoft searches both returned the entire 12,865,585-record corpus. Switched to POST with a Lucene-style `q` body combining all typed filters with AND, plus structured pagination.
- Returns MISSING_FILTER instead of dumping the full corpus when called with no filters.

Tests:
- New PPUBS tests assert AND default and that the search-query template is not mutated across sequential calls.
- New ODP tests assert POST/Lucene shape, multi-filter ANDing, quote escaping, free-text + typed-filter combining, and the no-filter error.
- 261 passed, 44 deselected.

Contributor docs:
- CONTRIBUTING.md and AGENTS.md (specific guidance for AI-agent contributors, complementing CONTRIBUTING.md).
- .github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml as YAML forms — bug_report prompts for the exact tool call, the constructed request body (LOG_LEVEL=DEBUG), and the raw response, which would have made #21 a one-turn fix.
- .github/PULL_REQUEST_TEMPLATE.md.
- README "Contributing" section + v0.9.4 history entry.

Version 0.9.3 -> 0.9.4 (pyproject.toml + config.py USER_AGENT).