### PR TITLE
v1.0.0: USPTO trademark support — TSDR, trademark search, and assignments (verified live)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,24 @@
 # USPTO API Configuration
 USPTO_API_KEY=your_uspto_api_key_here
 
-# PATENTSVIEW API KEY Configuration
+# TSDR trademark API key (optional - falls back to USPTO_API_KEY)
+# TSDR_API_KEY=your_tsdr_api_key_here
+
+# PATENTSVIEW API KEY Configuration (legacy - API shut down March 2026)
 PATENTSVIEW_API_KEY=your_patentsview_api_key_here
 
 # USPTO API Endpoints
 PPUBS_BASE_URL=https://ppubs.uspto.gov
 API_BASE_URL=https://api.uspto.gov
+TSDR_BASE_URL=https://tsdrapi.uspto.gov/ts/cd
+TMSEARCH_BASE_URL=https://tmsearch.uspto.gov
+TM_ASSIGNMENT_BASE_URL=https://assignment-api.uspto.gov
 
 # Logging Configuration
 LOG_LEVEL=INFO
 
 # HTTP Settings
-USER_AGENT=patent-mcp-server/0.2.3
+USER_AGENT=patent-mcp-server/1.0.0
 REQUEST_TIMEOUT=30.0
 
 # Rate Limiting & Retry Configuration

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 # USPTO API Configuration
 USPTO_API_KEY=your_uspto_api_key_here
 
-# TSDR trademark API key (optional - falls back to USPTO_API_KEY)
+# TSDR trademark API key. TSDR issues its OWN key — the ODP key does not
+# work (requests 404). Request one at https://account.uspto.gov/profile/api-manager
+# (select the "TSDR API" product).
 # TSDR_API_KEY=your_tsdr_api_key_here
+
+# Optional AWS WAF token for tmsearch.uspto.gov. Only needed if trademark
+# searches start failing with 403/202: copy the "aws-waf-token" cookie from
+# a browser session on tmsearch.uspto.gov (valid ~4 days).
+# TMSEARCH_WAF_TOKEN=your_waf_token_here
 
 # PATENTSVIEW API KEY Configuration (legacy - API shut down March 2026)
 PATENTSVIEW_API_KEY=your_patentsview_api_key_here
@@ -12,7 +19,7 @@ PPUBS_BASE_URL=https://ppubs.uspto.gov
 API_BASE_URL=https://api.uspto.gov
 TSDR_BASE_URL=https://tsdrapi.uspto.gov/ts/cd
 TMSEARCH_BASE_URL=https://tmsearch.uspto.gov
-TM_ASSIGNMENT_BASE_URL=https://assignment-api.uspto.gov
+TM_ASSIGNMENT_BASE_URL=https://assignmentcenter.uspto.gov
 
 # Logging Configuration
 LOG_LEVEL=INFO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,13 @@ This file provides guidance for Claude Code and other AI assistants working on t
 
 ## Project Overview
 
-This is a Model Context Protocol (MCP) server that provides access to USPTO patent data through multiple APIs. The server is built with FastMCP and uses async/await patterns throughout. Published to PyPI as `patent-mcp-server`.
+This is a Model Context Protocol (MCP) server that provides access to USPTO patent and trademark data through multiple APIs. The server is built with FastMCP and uses async/await patterns throughout. Published to PyPI as `patent-mcp-server`.
 
-**Current state (v0.9.5):** 52 registered tools, 27 active, 25 unavailable due to API shutdowns:
-- **Active:** PPUBS (5), ODP (12), PTAB (7), Utility (3)
+**Current state (v1.0.0):** 60 registered tools, 35 active, 25 unavailable due to API shutdowns:
+- **Active:** PPUBS (5), ODP (12), PTAB (7), TSDR (3), Trademark search/assignments (3), Utility (5)
 - **Unavailable:** PatentsView (14, shut down March 2026), Office Actions (4, decommissioned early 2026), Enriched Citations (3, decommissioned early 2026), Litigation (4, not offered on ODP — issue #16)
+
+**Unverified live contracts (verify when network access is available):** the trademark search client (`tmsearch_client.py`) targets the undocumented internal API behind tmsearch.uspto.gov with a best-effort request shape, and the trademark assignment client probes an ODP endpoint with legacy XML fallback. Run `uv run pytest -m integration -k trademark` with a real API key to verify; fix points are documented in each client's module docstring.
 
 ## Critical Rules
 
@@ -18,7 +20,7 @@ This is a Model Context Protocol (MCP) server that provides access to USPTO pate
 
 ```bash
 uv run pytest
-# Expected: ~221 passed, ~44 deselected (integration tests skipped by default)
+# Expected: ~336 passed, ~51 deselected (integration tests skipped by default)
 ```
 
 If tests fail, fix them before committing. Do not skip or delete failing tests unless the functionality has been intentionally removed.
@@ -86,6 +88,9 @@ src/patent_mcp_server/
 │   ├── ppubs_uspto_gov.py  # Patent Public Search client
 │   ├── api_uspto_gov.py    # Open Data Portal client
 │   ├── ptab_client.py      # PTAB proceedings client
+│   ├── tsdr_client.py      # TSDR trademark status/documents client
+│   ├── tmsearch_client.py  # Trademark search client (internal API, like PPUBS)
+│   ├── tm_assignment_client.py  # Trademark assignments (ODP + legacy fallback)
 │   ├── office_action_client.py   # Legacy - decommissioned early 2026
 │   ├── enriched_citation_client.py  # Legacy - decommissioned early 2026
 │   └── litigation_client.py
@@ -100,6 +105,8 @@ src/patent_mcp_server/
 - **PPUBS tools**: `ppubs_*` (e.g., `ppubs_search_patents`)
 - **ODP tools**: `odp_*` (e.g., `odp_get_application`)
 - **PTAB tools**: `ptab_*` (e.g., `ptab_search_proceedings`)
+- **TSDR tools**: `tsdr_*` (e.g., `tsdr_get_trademark_status`)
+- **Trademark search/assignment tools**: `tm_*` (e.g., `tm_search_trademarks`)
 - **PatentsView tools**: `patentsview_*` (legacy, all return API_UNAVAILABLE)
 
 ### Parameter Naming
@@ -107,6 +114,7 @@ src/patent_mcp_server/
 - Use `query` not `q` for search queries
 - Use `app_num` for application numbers
 - Use `patent_number` for patent numbers
+- Use `serial_number` and `registration_number` for trademarks (never `sn`/`rn`)
 - Use `offset` and `limit` for pagination
 
 ### Error Handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,14 @@ This file provides guidance for Claude Code and other AI assistants working on t
 
 This is a Model Context Protocol (MCP) server that provides access to USPTO patent and trademark data through multiple APIs. The server is built with FastMCP and uses async/await patterns throughout. Published to PyPI as `patent-mcp-server`.
 
-**Current state (v1.0.0):** 60 registered tools, 35 active, 25 unavailable due to API shutdowns:
-- **Active:** PPUBS (5), ODP (12), PTAB (7), TSDR (3), Trademark search/assignments (3), Utility (5)
+**Current state (v1.0.0):** 61 registered tools, 36 active, 25 unavailable due to API shutdowns:
+- **Active:** PPUBS (5), ODP (12), PTAB (7), TSDR (4), Trademark search/assignments (3), Utility (5)
 - **Unavailable:** PatentsView (14, shut down March 2026), Office Actions (4, decommissioned early 2026), Enriched Citations (3, decommissioned early 2026), Litigation (4, not offered on ODP — issue #16)
 
-**Unverified live contracts (verify when network access is available):** the trademark search client (`tmsearch_client.py`) targets the undocumented internal API behind tmsearch.uspto.gov with a best-effort request shape, and the trademark assignment client probes an ODP endpoint with legacy XML fallback. Run `uv run pytest -m integration -k trademark` with a real API key to verify; fix points are documented in each client's module docstring.
+**Trademark backend contracts (verified live 2026-06-10):**
+- **tmsearch** (`tmsearch_client.py`): `POST tmsearch.uspto.gov/prod-stage-v1-0-0/tmsearch`, Elasticsearch-style body, non-standard response envelope (`hits.totalValue`, hit `source`/`id`). No key; behind AWS WAF (currently permissive — `TMSEARCH_WAF_TOKEN` supported as escape hatch). Class filters need zero-padded 3-digit terms ("025").
+- **Assignments** (`tm_assignment_client.py`): `POST assignmentcenter.uspto.gov/ipas/search/api/v2/public/trademark/exportTradeMarkData` with `searchCriteria` list; no key. The legacy assignment-api.uspto.gov died with the Developer Hub on June 5, 2026.
+- **TSDR** (`tsdr_client.py`): requires a TSDR-specific key from account.uspto.gov/profile/api-manager — the ODP key passes the gateway but 404s on the backend (`BACKEND RESPONSE STATUS: 404`); the client detects this and explains. Status uses `/info` + `Accept: application/json`; the document list at `/casedocs/{caseid}/info` is XML-ONLY (406 on JSON Accept) and is parsed via `_parse_document_list_xml`. Binary bundles are capped at `TrademarkDefaults.MAX_BINARY_BYTES` (full wrappers can exceed 10 MB) — filter by `document_type`/date. All endpoints verified live 2026-06-10 with a real TSDR key.
 
 ## Critical Rules
 
@@ -20,7 +23,7 @@ This is a Model Context Protocol (MCP) server that provides access to USPTO pate
 
 ```bash
 uv run pytest
-# Expected: ~336 passed, ~51 deselected (integration tests skipped by default)
+# Expected: ~359 passed, ~54 deselected (integration tests skipped by default)
 ```
 
 If tests fail, fix them before committing. Do not skip or delete failing tests unless the functionality has been intentionally removed.
@@ -88,9 +91,9 @@ src/patent_mcp_server/
 │   ├── ppubs_uspto_gov.py  # Patent Public Search client
 │   ├── api_uspto_gov.py    # Open Data Portal client
 │   ├── ptab_client.py      # PTAB proceedings client
-│   ├── tsdr_client.py      # TSDR trademark status/documents client
+│   ├── tsdr_client.py      # TSDR trademark status/documents client (TSDR-specific key)
 │   ├── tmsearch_client.py  # Trademark search client (internal API, like PPUBS)
-│   ├── tm_assignment_client.py  # Trademark assignments (ODP + legacy fallback)
+│   ├── tm_assignment_client.py  # Trademark assignments (Assignment Center, no key)
 │   ├── office_action_client.py   # Legacy - decommissioned early 2026
 │   ├── enriched_citation_client.py  # Legacy - decommissioned early 2026
 │   └── litigation_client.py
@@ -160,7 +163,9 @@ uv sync --dev              # Install dev dependencies
 ## Configuration
 
 Environment variables are loaded from `.env` file:
-- `USPTO_API_KEY` - Required for ODP, PTAB, and Litigation tools
+- `USPTO_API_KEY` - Required for ODP and PTAB tools
+- `TSDR_API_KEY` - Required for TSDR trademark tools (separate key from ODP — see account.uspto.gov/profile/api-manager)
+- `TMSEARCH_WAF_TOKEN` - Optional escape hatch if tmsearch.uspto.gov tightens its AWS WAF
 - `LOG_LEVEL` - Logging verbosity (default: INFO)
 
 See `config.py` for all options.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# USPTO Patent MCP Server
+# USPTO Patent & Trademark MCP Server
 
-A [FastMCP server](https://github.com/modelcontextprotocol/python-sdk/tree/main/src/mcp/server/fastmcp) for accessing United States Patent and Trademark Office (USPTO) patent and patent application data through multiple APIs including the [Patent Public Search](https://www.uspto.gov/patents/search/patent-public-search) API, the [Open Data Portal (ODP) API](https://data.uspto.gov/home), [PTAB API v3](https://developer.uspto.gov/api-catalog), and Patent Litigation APIs. Using this server, Claude Desktop can pull data from USPTO APIs, search through PTAB proceedings and decisions, analyze patent litigation, research prosecution history, and more:
+A [FastMCP server](https://github.com/modelcontextprotocol/python-sdk/tree/main/src/mcp/server/fastmcp) for accessing United States Patent and Trademark Office (USPTO) patent **and trademark** data through multiple APIs including the [Patent Public Search](https://www.uspto.gov/patents/search/patent-public-search) API, the [Open Data Portal (ODP) API](https://data.uspto.gov/home), PTAB API v3, the [TSDR](https://tsdr.uspto.gov/) trademark status API, and [USPTO trademark search](https://tmsearch.uspto.gov/). Using this server, Claude Desktop can pull data from USPTO APIs, search through PTAB proceedings and decisions, research prosecution history, run trademark clearance searches, track trademark status, and more:
 
 ![Screen Capture of Claude Desktop using Patents MCP Server](screencap.gif)
 
@@ -10,7 +10,7 @@ Special thanks to [Parker Hancock](https://github.com/parkerhancock), author of 
 
 ## Features
 
-This server provides **52 tools** across 6 USPTO data sources (27 active, 25 unavailable due to API shutdowns):
+This server provides **60 tools** across 9 USPTO data sources (35 active, 25 unavailable due to API shutdowns):
 
 1. **Patent Search** - Full-text search of granted patents and published applications via PPUBS
 2. **Full Text Documents** - Get complete text of patents including claims, description, and specification
@@ -18,6 +18,9 @@ This server provides **52 tools** across 6 USPTO data sources (27 active, 25 una
 4. **Prosecution History** - Access transactions and file wrapper data via ODP
 5. **Patent Family Data** - Continuity information, foreign priority, and related applications
 6. **Bulk Datasets** - Search and access USPTO bulk data products including PatentsView disambiguated data
+7. **Trademark Search** - Full-text search of US federal trademarks by mark text, owner, and class (clearance/knockout searches)
+8. **Trademark Status & Documents** - Authoritative live status, prosecution documents, and mark images via TSDR
+9. **Trademark Assignments** - Recorded ownership transfer records from 1955 to present
 
 > **Note on unavailable APIs:** The PatentsView API (search.patentsview.org) was shut down on March 20, 2026, with its data migrated to ODP bulk datasets. The Office Action and Enriched Citation APIs (developer.uspto.gov) were decommissioned in early 2026. The Patent Litigation API is not offered on the USPTO Open Data Portal; litigation data is available as a bulk download. All 25 affected tools remain registered and return helpful workaround guidance pointing to alternative tools.
 
@@ -28,6 +31,9 @@ This server provides **52 tools** across 6 USPTO data sources (27 active, 25 una
 | **ppubs.uspto.gov** | Full text documents, PDF downloads, advanced search (daily updates) | No | Active |
 | **api.uspto.gov (ODP)** | Metadata, continuity, transactions, assignments, prosecution history | Yes (ODP API Key) | Active |
 | **PTAB Trial API** | IPR/PGR/CBM proceedings, decisions, appeals | Yes (ODP API Key) | Active (ODP v3.0) |
+| **tsdrapi.uspto.gov (TSDR)** | Trademark status, prosecution documents, mark images | Yes (API Key) | Active |
+| **tmsearch.uspto.gov** | Full-text trademark search (internal API behind the TESS replacement) | No | Active (unofficial) |
+| **Trademark Assignment Search** | Trademark ownership transfer records (1955-present) | Yes (ODP API Key) | Active (ODP, legacy fallback) |
 | **Patent Litigation API** | 74,000+ district court patent cases | N/A | Not offered on ODP (issue #16) |
 | **PatentsView API** | Disambiguated inventor/assignee data, advanced search | N/A | Shut down March 2026 |
 | **Office Action APIs** | Full-text office actions, citations, rejections | N/A | Decommissioned early 2026 |
@@ -71,7 +77,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ### USPTO ODP API Key (Required for most tools)
 
-To use the api.uspto.gov tools (ODP, PTAB), you need an Open Data Portal API key. Without it, these endpoints return `403 Forbidden`. The Patent Litigation API is not offered on ODP and does not require an API key.
+To use the api.uspto.gov tools (ODP, PTAB) and trademark assignment search, you need an Open Data Portal API key. Without it, these endpoints return `403 Forbidden`. The Patent Litigation API is not offered on ODP and does not require an API key.
 
 1. Create a USPTO.gov account at [data.uspto.gov](https://data.uspto.gov) (requires ID.me verification)
 2. Once signed in, visit **"My ODP"** in the site navigation to get your API key
@@ -81,7 +87,17 @@ To use the api.uspto.gov tools (ODP, PTAB), you need an Open Data Portal API key
    ```bash
    USPTO_API_KEY=your_actual_key_here
    ```
-   Note: The PPUBS tools will work without this API key.
+   Note: The PPUBS and trademark search (`tm_search_trademarks`) tools will work without this API key.
+
+### TSDR API Key (Trademark status/document tools)
+
+The TSDR tools (`tsdr_*`) send an API key as the `USPTO-API-KEY` header. By default they reuse `USPTO_API_KEY`; if your TSDR key differs, set it separately:
+
+```bash
+TSDR_API_KEY=your_tsdr_key_here   # optional, falls back to USPTO_API_KEY
+```
+
+TSDR rate limits: 60 requests/minute general, 4 requests/minute for PDF document bundles.
 
 ## Configuration
 
@@ -90,6 +106,7 @@ The server can be configured using environment variables in your `.env` file. Al
 ```bash
 # API Keys
 USPTO_API_KEY=your_key_here
+TSDR_API_KEY=your_tsdr_key_here  # Optional - falls back to USPTO_API_KEY
 
 # Logging
 LOG_LEVEL=INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
@@ -107,6 +124,9 @@ ENABLE_CACHING=true        # Enable/disable session caching
 # API Endpoints (usually don't need to change)
 PPUBS_BASE_URL=https://ppubs.uspto.gov
 API_BASE_URL=https://api.uspto.gov          # ODP API endpoint (NOT data.uspto.gov)
+TSDR_BASE_URL=https://tsdrapi.uspto.gov/ts/cd
+TMSEARCH_BASE_URL=https://tmsearch.uspto.gov
+TM_ASSIGNMENT_BASE_URL=https://assignment-api.uspto.gov  # Legacy fallback
 ```
 
 ## Claude Desktop Configuration
@@ -154,6 +174,8 @@ If you're already running Claude Code, you'll have to /exit and restart. Then /m
 | `check_api_status` | Check status of all USPTO APIs |
 | `get_cpc_info` | Get CPC classification information |
 | `get_status_code` | Look up USPTO status code meaning |
+| `get_trademark_class_info` | Look up a Nice/international trademark class (1-45) |
+| `get_trademark_status_code` | Look up a USPTO trademark status code meaning |
 
 ### Patent Public Search (ppubs.uspto.gov)
 | Tool | Description |
@@ -190,6 +212,22 @@ If you're already running Claude Code, you'll have to /exit and restart. Then /m
 | `ptab_get_decision` | Get a specific decision by trial number |
 | `ptab_search_appeals` | Search ex parte appeals |
 | `ptab_get_appeal` | Get details for a specific appeal |
+
+### TSDR - Trademark Status and Document Retrieval (tsdrapi.uspto.gov)
+| Tool | Description |
+|------|-------------|
+| `tsdr_get_trademark_status` | Get authoritative live status by serial or registration number |
+| `tsdr_download_trademark_documents` | Download prosecution document bundle as PDF (4/min rate limit) |
+| `tsdr_get_trademark_image` | Get the mark image (drawing) as base64 |
+
+### Trademark Search & Assignments
+| Tool | Description |
+|------|-------------|
+| `tm_search_trademarks` | Full-text search by mark text, owner, class, live/dead status |
+| `tm_get_trademark` | Get a trademark's search-index record by serial number |
+| `tm_search_assignments` | Search recorded ownership transfers (1955-present) |
+
+> **Note:** `tm_search_trademarks` and `tm_get_trademark` use the undocumented internal API behind [tmsearch.uspto.gov](https://tmsearch.uspto.gov) (the TESS replacement) — the same situation as the PPUBS patent search API. USPTO offers no official REST API for full-text trademark search. These tools may break without notice if USPTO changes the internal API. TTAB proceedings (oppositions/cancellations) have no REST API; daily TTAB XML is available as bulk datasets via `odp_search_datasets`.
 
 ### Patent Litigation API (Unavailable — not offered on ODP, issue #16)
 
@@ -250,15 +288,20 @@ The server also provides **MCP Resources** (accessible via @ mentions):
 - `patents://cpc/{code}` - CPC classification information
 - `patents://status-codes` - USPTO status code definitions
 - `patents://sources` - Data source information
-- `patents://search-syntax` - Query syntax guide
+- `patents://search-syntax` - Query syntax guide (patents and trademarks)
+- `trademarks://classes` - Nice/international trademark classes (1-45)
+- `trademarks://status-codes` - Trademark status code definitions
 
 And **MCP Prompts** (workflow templates):
 - `prior_art_search` - Comprehensive prior art search guide
 - `patent_validity` - Patent validity analysis workflow
-- `competitor_portfolio` - Competitor portfolio analysis
+- `competitor_portfolio` - Competitor portfolio analysis (patents + trademarks)
 - `ptab_research` - PTAB proceeding research guide
 - `freedom_to_operate` - FTO analysis workflow
 - `patent_landscape` - Technology landscape mapping
+- `trademark_clearance_search` - Trademark clearance/knockout search guide
+- `trademark_portfolio_review` - Trademark portfolio and deadline review
+- `trademark_status_monitoring` - Trademark status and conflict watching
 
 ## Testing
 
@@ -306,7 +349,19 @@ Issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribut
 
 ## Version History
 
-### v0.9.5 (Current)
+### v1.0.0 (Current)
+- **Trademark support**: 8 new trademark tools across three new clients
+  - TSDR (`tsdr_get_trademark_status`, `tsdr_download_trademark_documents`, `tsdr_get_trademark_image`) — official trademark status/document API with `USPTO-API-KEY` auth and 429 rate-limit handling
+  - Trademark search (`tm_search_trademarks`, `tm_get_trademark`) — full-text search via the internal API behind tmsearch.uspto.gov (no official REST API exists)
+  - Trademark assignments (`tm_search_assignments`) — ODP-first with automatic fallback to the legacy assignment-api.uspto.gov XML API
+- New reference tools and resources: `get_trademark_class_info`, `get_trademark_status_code`, `trademarks://classes`, `trademarks://status-codes` (all 45 Nice classes, common trademark status codes)
+- 3 new workflow prompts: `trademark_clearance_search`, `trademark_portfolio_review`, `trademark_status_monitoring`
+- Fixed `ppubs_download_patent_pdf` (called `download_image` with the wrong signature, raising `TypeError`)
+- Rewrote patent workflow prompts to reference live tools (the old prompts still pointed at decommissioned PatentsView/Office Action/citation tools)
+- New env vars: `TSDR_API_KEY` (falls back to `USPTO_API_KEY`), `TSDR_BASE_URL`, `TMSEARCH_BASE_URL`, `TM_ASSIGNMENT_BASE_URL`
+- Tool count: 60 registered (35 active, 25 unavailable)
+
+### v0.9.5
 - Re-enable 7 PTAB tools on USPTO ODP v3.0: `ptab_search_proceedings`, `ptab_get_proceeding`, `ptab_get_documents`, `ptab_search_decisions`, `ptab_get_decision`, `ptab_search_appeals`, `ptab_get_appeal` ([issue #23](https://github.com/riemannzeta/patent_mcp_server/issues/23)). PTAB data relocated to ODP `/api/v1/patent/trials/*` and `/api/v1/patent/appeals/*` (paths not in the ODP Swagger UI); the standalone-API decommission ([issue #16](https://github.com/riemannzeta/patent_mcp_server/issues/16)) was correct for the Patent Litigation API, but PTAB moved rather than disappeared.
 - Active tool count: 27 (up from 20); unavailable: 25 (down from 32); total registered remains 52
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Special thanks to [Parker Hancock](https://github.com/parkerhancock), author of 
 
 ## Features
 
-This server provides **60 tools** across 9 USPTO data sources (35 active, 25 unavailable due to API shutdowns):
+This server provides **61 tools** across 9 USPTO data sources (36 active, 25 unavailable due to API shutdowns):
 
 1. **Patent Search** - Full-text search of granted patents and published applications via PPUBS
 2. **Full Text Documents** - Get complete text of patents including claims, description, and specification
@@ -18,9 +18,9 @@ This server provides **60 tools** across 9 USPTO data sources (35 active, 25 una
 4. **Prosecution History** - Access transactions and file wrapper data via ODP
 5. **Patent Family Data** - Continuity information, foreign priority, and related applications
 6. **Bulk Datasets** - Search and access USPTO bulk data products including PatentsView disambiguated data
-7. **Trademark Search** - Full-text search of US federal trademarks by mark text, owner, and class (clearance/knockout searches)
+7. **Trademark Search** - Full-text search of US federal trademarks by mark text, owner, goods/services, and class (clearance/knockout searches)
 8. **Trademark Status & Documents** - Authoritative live status, prosecution documents, and mark images via TSDR
-9. **Trademark Assignments** - Recorded ownership transfer records from 1955 to present
+9. **Trademark Assignments** - Recorded ownership transfer records from 1955 to present (no API key needed)
 
 > **Note on unavailable APIs:** The PatentsView API (search.patentsview.org) was shut down on March 20, 2026, with its data migrated to ODP bulk datasets. The Office Action and Enriched Citation APIs (developer.uspto.gov) were decommissioned in early 2026. The Patent Litigation API is not offered on the USPTO Open Data Portal; litigation data is available as a bulk download. All 25 affected tools remain registered and return helpful workaround guidance pointing to alternative tools.
 
@@ -31,9 +31,9 @@ This server provides **60 tools** across 9 USPTO data sources (35 active, 25 una
 | **ppubs.uspto.gov** | Full text documents, PDF downloads, advanced search (daily updates) | No | Active |
 | **api.uspto.gov (ODP)** | Metadata, continuity, transactions, assignments, prosecution history | Yes (ODP API Key) | Active |
 | **PTAB Trial API** | IPR/PGR/CBM proceedings, decisions, appeals | Yes (ODP API Key) | Active (ODP v3.0) |
-| **tsdrapi.uspto.gov (TSDR)** | Trademark status, prosecution documents, mark images | Yes (API Key) | Active |
+| **tsdrapi.uspto.gov (TSDR)** | Trademark status, prosecution documents, mark images | Yes (TSDR API Key — separate from ODP) | Active |
 | **tmsearch.uspto.gov** | Full-text trademark search (internal API behind the TESS replacement) | No | Active (unofficial) |
-| **Trademark Assignment Search** | Trademark ownership transfer records (1955-present) | Yes (ODP API Key) | Active (ODP, legacy fallback) |
+| **assignmentcenter.uspto.gov** | Trademark ownership transfer records (1955-present) | No | Active |
 | **Patent Litigation API** | 74,000+ district court patent cases | N/A | Not offered on ODP (issue #16) |
 | **PatentsView API** | Disambiguated inventor/assignee data, advanced search | N/A | Shut down March 2026 |
 | **Office Action APIs** | Full-text office actions, citations, rejections | N/A | Decommissioned early 2026 |
@@ -77,7 +77,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ### USPTO ODP API Key (Required for most tools)
 
-To use the api.uspto.gov tools (ODP, PTAB) and trademark assignment search, you need an Open Data Portal API key. Without it, these endpoints return `403 Forbidden`. The Patent Litigation API is not offered on ODP and does not require an API key.
+To use the api.uspto.gov tools (ODP, PTAB), you need an Open Data Portal API key. Without it, these endpoints return `403 Forbidden`. The Patent Litigation API is not offered on ODP and does not require an API key.
 
 1. Create a USPTO.gov account at [data.uspto.gov](https://data.uspto.gov) (requires ID.me verification)
 2. Once signed in, visit **"My ODP"** in the site navigation to get your API key
@@ -87,17 +87,28 @@ To use the api.uspto.gov tools (ODP, PTAB) and trademark assignment search, you 
    ```bash
    USPTO_API_KEY=your_actual_key_here
    ```
-   Note: The PPUBS and trademark search (`tm_search_trademarks`) tools will work without this API key.
+   Note: The PPUBS patent tools, trademark search (`tm_*` search tools), and trademark assignment search work without any API key.
 
 ### TSDR API Key (Trademark status/document tools)
 
-The TSDR tools (`tsdr_*`) send an API key as the `USPTO-API-KEY` header. By default they reuse `USPTO_API_KEY`; if your TSDR key differs, set it separately:
+The TSDR tools (`tsdr_*`) require a **TSDR-specific API key** sent as the `USPTO-API-KEY` header. **The ODP key does not work for TSDR** — it passes the gateway's auth check, but every request then fails with `BACKEND RESPONSE STATUS: 404`.
+
+1. Sign in to the [USPTO API Key Manager](https://account.uspto.gov/profile/api-manager) with a free MyUSPTO account
+2. Select the **TSDR API** product and click "Request API key" (the key is emailed and stored under your account)
+3. Add it to your `.env`:
+   ```bash
+   TSDR_API_KEY=your_tsdr_key_here
+   ```
+
+TSDR rate limits (peak hours 5am-10pm ET): 60 requests/minute general, 4 requests/minute for PDF document bundles (120/12 off-peak). Use `tsdr_list_trademark_documents` (metadata only, not rate-limited like PDFs) before downloading bundles.
+
+### Trademark search and AWS WAF (no key needed)
+
+`tm_search_trademarks` / `tm_get_trademark` use the internal API behind [tmsearch.uspto.gov](https://tmsearch.uspto.gov), which sits behind AWS WAF. It currently answers plain requests, but if USPTO tightens the WAF and searches start failing with 403/202 errors, copy the `aws-waf-token` cookie from a browser session on tmsearch.uspto.gov (valid ~4 days) and set:
 
 ```bash
-TSDR_API_KEY=your_tsdr_key_here   # optional, falls back to USPTO_API_KEY
+TMSEARCH_WAF_TOKEN=your_cookie_value_here
 ```
-
-TSDR rate limits: 60 requests/minute general, 4 requests/minute for PDF document bundles.
 
 ## Configuration
 
@@ -105,8 +116,9 @@ The server can be configured using environment variables in your `.env` file. Al
 
 ```bash
 # API Keys
-USPTO_API_KEY=your_key_here
-TSDR_API_KEY=your_tsdr_key_here  # Optional - falls back to USPTO_API_KEY
+USPTO_API_KEY=your_key_here      # ODP/PTAB tools
+TSDR_API_KEY=your_tsdr_key_here  # TSDR trademark tools (separate key — see above)
+TMSEARCH_WAF_TOKEN=...           # Optional - only if trademark search hits the WAF
 
 # Logging
 LOG_LEVEL=INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
@@ -126,7 +138,7 @@ PPUBS_BASE_URL=https://ppubs.uspto.gov
 API_BASE_URL=https://api.uspto.gov          # ODP API endpoint (NOT data.uspto.gov)
 TSDR_BASE_URL=https://tsdrapi.uspto.gov/ts/cd
 TMSEARCH_BASE_URL=https://tmsearch.uspto.gov
-TM_ASSIGNMENT_BASE_URL=https://assignment-api.uspto.gov  # Legacy fallback
+TM_ASSIGNMENT_BASE_URL=https://assignmentcenter.uspto.gov
 ```
 
 ## Claude Desktop Configuration
@@ -217,17 +229,18 @@ If you're already running Claude Code, you'll have to /exit and restart. Then /m
 | Tool | Description |
 |------|-------------|
 | `tsdr_get_trademark_status` | Get authoritative live status by serial or registration number |
+| `tsdr_list_trademark_documents` | List prosecution document metadata (no rate limit, no downloads) |
 | `tsdr_download_trademark_documents` | Download prosecution document bundle as PDF (4/min rate limit) |
 | `tsdr_get_trademark_image` | Get the mark image (drawing) as base64 |
 
 ### Trademark Search & Assignments
 | Tool | Description |
 |------|-------------|
-| `tm_search_trademarks` | Full-text search by mark text, owner, class, live/dead status |
+| `tm_search_trademarks` | Full-text search by mark text, owner, goods/services, class, live/dead status |
 | `tm_get_trademark` | Get a trademark's search-index record by serial number |
-| `tm_search_assignments` | Search recorded ownership transfers (1955-present) |
+| `tm_search_assignments` | Search recorded ownership transfers, 1955-present (Assignment Center, no key) |
 
-> **Note:** `tm_search_trademarks` and `tm_get_trademark` use the undocumented internal API behind [tmsearch.uspto.gov](https://tmsearch.uspto.gov) (the TESS replacement) — the same situation as the PPUBS patent search API. USPTO offers no official REST API for full-text trademark search. These tools may break without notice if USPTO changes the internal API. TTAB proceedings (oppositions/cancellations) have no REST API; daily TTAB XML is available as bulk datasets via `odp_search_datasets`.
+> **Note:** `tm_search_trademarks` and `tm_get_trademark` use the undocumented internal API behind [tmsearch.uspto.gov](https://tmsearch.uspto.gov) (the TESS replacement) — the same situation as the PPUBS patent search API. USPTO offers no official REST API for full-text trademark search. The request/response contract was verified live on 2026-06-10, but these tools may break without notice if USPTO changes the internal API. TTAB proceedings (oppositions/cancellations) have no REST API; daily TTAB XML is available as bulk datasets via `odp_search_datasets`.
 
 ### Patent Litigation API (Unavailable — not offered on ODP, issue #16)
 
@@ -350,16 +363,16 @@ Issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribut
 ## Version History
 
 ### v1.0.0 (Current)
-- **Trademark support**: 8 new trademark tools across three new clients
-  - TSDR (`tsdr_get_trademark_status`, `tsdr_download_trademark_documents`, `tsdr_get_trademark_image`) — official trademark status/document API with `USPTO-API-KEY` auth and 429 rate-limit handling
-  - Trademark search (`tm_search_trademarks`, `tm_get_trademark`) — full-text search via the internal API behind tmsearch.uspto.gov (no official REST API exists)
-  - Trademark assignments (`tm_search_assignments`) — ODP-first with automatic fallback to the legacy assignment-api.uspto.gov XML API
+- **Trademark support**: 9 new trademark tools across three new clients, all verified against the live USPTO services on 2026-06-10
+  - TSDR (`tsdr_get_trademark_status`, `tsdr_list_trademark_documents`, `tsdr_download_trademark_documents`, `tsdr_get_trademark_image`) — official trademark status/document API. Requires a TSDR-specific key (the ODP key does not work); error responses detect the wrong-key signature and explain how to get the right one. Document bundles above 4 MB are rejected with filter guidance (full wrappers can exceed 10 MB)
+  - Trademark search (`tm_search_trademarks`, `tm_get_trademark`) — full-text search by mark text, owner, goods/services, and Nice class via the internal Elasticsearch API behind tmsearch.uspto.gov (no official REST API exists). Verified live; handles AWS WAF rejections with `TMSEARCH_WAF_TOKEN` support
+  - Trademark assignments (`tm_search_assignments`) — USPTO Assignment Center public API (assignmentcenter.uspto.gov, no key required), searchable by serial/registration number, assignee, assignor, and reel/frame. Replaced the legacy assignment-api.uspto.gov XML API decommissioned June 5, 2026
 - New reference tools and resources: `get_trademark_class_info`, `get_trademark_status_code`, `trademarks://classes`, `trademarks://status-codes` (all 45 Nice classes, common trademark status codes)
 - 3 new workflow prompts: `trademark_clearance_search`, `trademark_portfolio_review`, `trademark_status_monitoring`
 - Fixed `ppubs_download_patent_pdf` (called `download_image` with the wrong signature, raising `TypeError`)
 - Rewrote patent workflow prompts to reference live tools (the old prompts still pointed at decommissioned PatentsView/Office Action/citation tools)
-- New env vars: `TSDR_API_KEY` (falls back to `USPTO_API_KEY`), `TSDR_BASE_URL`, `TMSEARCH_BASE_URL`, `TM_ASSIGNMENT_BASE_URL`
-- Tool count: 60 registered (35 active, 25 unavailable)
+- New env vars: `TSDR_API_KEY`, `TMSEARCH_WAF_TOKEN`, `TSDR_BASE_URL`, `TMSEARCH_BASE_URL`, `TM_ASSIGNMENT_BASE_URL`
+- Tool count: 61 registered (36 active, 25 unavailable)
 
 ### v0.9.5
 - Re-enable 7 PTAB tools on USPTO ODP v3.0: `ptab_search_proceedings`, `ptab_get_proceeding`, `ptab_get_documents`, `ptab_search_decisions`, `ptab_get_decision`, `ptab_search_appeals`, `ptab_get_appeal` ([issue #23](https://github.com/riemannzeta/patent_mcp_server/issues/23)). PTAB data relocated to ODP `/api/v1/patent/trials/*` and `/api/v1/patent/appeals/*` (paths not in the ODP Swagger UI); the standalone-API decommission ([issue #16](https://github.com/riemannzeta/patent_mcp_server/issues/16)) was correct for the Patent Litigation API, but PTAB moved rather than disappeared.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "patent-mcp-server"
-version = "0.9.5"
-description = "Model Context Protocol server for USPTO patent data"
+version = "1.0.0"
+description = "Model Context Protocol server for USPTO patent and trademark data"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
 authors = [
     {name = "riemannzeta", email = "noreply@github.com"}
 ]
-keywords = ["mcp", "model-context-protocol", "uspto", "patent", "patent-search", "api"]
+keywords = ["mcp", "model-context-protocol", "uspto", "patent", "patent-search", "trademark", "trademark-search", "tsdr", "api"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,9 @@ python_functions = test_*
 
 # Asyncio configuration
 asyncio_mode = auto
+# Session-scoped loop so module-level async clients (patents.py) survive
+# across integration tests instead of binding to the first test's loop
+asyncio_default_test_loop_scope = session
 
 # Markers for categorizing tests
 markers =

--- a/src/patent_mcp_server/config.py
+++ b/src/patent_mcp_server/config.py
@@ -35,9 +35,16 @@ class Config:
     # Trademark APIs (v1.0.0)
     TSDR_BASE_URL: str = os.getenv("TSDR_BASE_URL", "https://tsdrapi.uspto.gov/ts/cd")
     TMSEARCH_BASE_URL: str = os.getenv("TMSEARCH_BASE_URL", "https://tmsearch.uspto.gov")
-    TM_ASSIGNMENT_BASE_URL: str = os.getenv("TM_ASSIGNMENT_BASE_URL", "https://assignment-api.uspto.gov")  # Legacy fallback host
-    # TSDR accepts its own key; defaults to the ODP key (both issued via USPTO accounts)
+    TM_ASSIGNMENT_BASE_URL: str = os.getenv("TM_ASSIGNMENT_BASE_URL", "https://assignmentcenter.uspto.gov")
+    # TSDR requires its OWN key (account.uspto.gov/profile/api-manager, "TSDR API"
+    # product) — the ODP key authenticates at the gateway but the backend 404s.
+    # The ODP fallback is kept for users who store a TSDR key in USPTO_API_KEY.
     TSDR_API_KEY: Optional[str] = os.getenv("TSDR_API_KEY") or os.getenv("USPTO_API_KEY")
+    # Optional AWS WAF token cookie for tmsearch.uspto.gov. The internal search
+    # API currently answers plain requests, but sits behind AWS WAF; if USPTO
+    # tightens it, copy the "aws-waf-token" cookie value from a browser session
+    # on tmsearch.uspto.gov (valid ~4 days) and set it here.
+    TMSEARCH_WAF_TOKEN: Optional[str] = os.getenv("TMSEARCH_WAF_TOKEN")
 
     # Logging
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
@@ -88,12 +95,22 @@ class Config:
                 "unavailable on ODP entirely (see issue #16)."
             )
 
-        if not cls.TSDR_API_KEY:
-            logger.warning(
-                "TSDR_API_KEY not set (and no USPTO_API_KEY fallback). TSDR trademark "
-                "tools (tsdrapi.uspto.gov) will return 401. Request an API key via "
-                "your USPTO.gov account, or set USPTO_API_KEY."
-            )
+        if not os.getenv("TSDR_API_KEY"):
+            if cls.TSDR_API_KEY:
+                logger.warning(
+                    "TSDR_API_KEY not set; falling back to USPTO_API_KEY for TSDR. "
+                    "NOTE: TSDR requires its own key (the ODP key usually does NOT "
+                    "work — requests return 404). Request a TSDR API key at "
+                    "https://account.uspto.gov/profile/api-manager (select the "
+                    "'TSDR API' product) and set TSDR_API_KEY."
+                )
+            else:
+                logger.warning(
+                    "TSDR_API_KEY not set. TSDR trademark tools (tsdrapi.uspto.gov) "
+                    "will return 401. Request a TSDR API key at "
+                    "https://account.uspto.gov/profile/api-manager (select the "
+                    "'TSDR API' product)."
+                )
 
         # PatentsView API was shut down March 20, 2026 - no longer warn about missing key
 

--- a/src/patent_mcp_server/config.py
+++ b/src/patent_mcp_server/config.py
@@ -32,11 +32,18 @@ class Config:
     # Office Action API
     OFFICE_ACTION_BASE_URL: str = os.getenv("OFFICE_ACTION_BASE_URL", "https://developer.uspto.gov")  # Legacy - decommissioned early 2026, pending ODP migration
 
+    # Trademark APIs (v1.0.0)
+    TSDR_BASE_URL: str = os.getenv("TSDR_BASE_URL", "https://tsdrapi.uspto.gov/ts/cd")
+    TMSEARCH_BASE_URL: str = os.getenv("TMSEARCH_BASE_URL", "https://tmsearch.uspto.gov")
+    TM_ASSIGNMENT_BASE_URL: str = os.getenv("TM_ASSIGNMENT_BASE_URL", "https://assignment-api.uspto.gov")  # Legacy fallback host
+    # TSDR accepts its own key; defaults to the ODP key (both issued via USPTO accounts)
+    TSDR_API_KEY: Optional[str] = os.getenv("TSDR_API_KEY") or os.getenv("USPTO_API_KEY")
+
     # Logging
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
 
     # HTTP Settings
-    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/0.9.5")
+    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/1.0.0")
     REQUEST_TIMEOUT: float = float(os.getenv("REQUEST_TIMEOUT", "30.0"))
 
     # Rate Limiting & Retry
@@ -79,6 +86,13 @@ class Config:
                 "Register at https://data.uspto.gov and visit 'My ODP' to get your API key. "
                 "Note: PTAB and Litigation tools do not require an API key — they are "
                 "unavailable on ODP entirely (see issue #16)."
+            )
+
+        if not cls.TSDR_API_KEY:
+            logger.warning(
+                "TSDR_API_KEY not set (and no USPTO_API_KEY fallback). TSDR trademark "
+                "tools (tsdrapi.uspto.gov) will return 401. Request an API key via "
+                "your USPTO.gov account, or set USPTO_API_KEY."
             )
 
         # PatentsView API was shut down March 20, 2026 - no longer warn about missing key

--- a/src/patent_mcp_server/constants.py
+++ b/src/patent_mcp_server/constants.py
@@ -185,6 +185,37 @@ class PTABFields:
     DECISION_ISSUE_DATE = "decisionData.decisionIssueDate"
 
 
+class TrademarkDefaults:
+    """Default values for trademark operations."""
+    SEARCH_LIMIT = 25
+    SEARCH_LIMIT_MAX = 100
+    # TSDR enforced limits (per API key): 60 req/min general, 4 req/min PDF/ZIP
+    TSDR_RATE_LIMIT_PER_MIN = 60
+    TSDR_PDF_RATE_LIMIT_PER_MIN = 4
+
+
+class TmSearchFields:
+    """Field names for the tmsearch.uspto.gov internal search index.
+
+    BEST-EFFORT SHAPE — NOT verified live. tmsearch.uspto.gov is the
+    undocumented internal API behind the USPTO trademark search web app
+    (TESS replacement). These names are drawn from public observations of
+    the web app's network calls and may change without notice. Confirm
+    against live traffic (browser dev tools on tmsearch.uspto.gov) before
+    relying on them; this class is the single place to fix names.
+    """
+    WORDMARK = "wordmark"
+    OWNER = "ownerFullText"
+    SERIAL_NUMBER = "id"
+    REGISTRATION_NUMBER = "registrationId"
+    INTERNATIONAL_CLASS = "internationalClasses"
+    ALIVE = "alive"
+    GOODS_AND_SERVICES = "goodsAndServices"
+    MARK_TYPE = "markType"
+    REGISTRATION_DATE = "registrationDate"
+    ABANDON_DATE = "abandonDate"
+
+
 class OfficeActionTypes:
     """Office Action types."""
     NON_FINAL = "Non-Final Rejection"

--- a/src/patent_mcp_server/constants.py
+++ b/src/patent_mcp_server/constants.py
@@ -192,28 +192,39 @@ class TrademarkDefaults:
     # TSDR enforced limits (per API key): 60 req/min general, 4 req/min PDF/ZIP
     TSDR_RATE_LIMIT_PER_MIN = 60
     TSDR_PDF_RATE_LIMIT_PER_MIN = 4
+    # Cap on binary (PDF/image) payloads returned through MCP. Full file
+    # wrappers can exceed 10 MB (NIKE's is 13 MB); base64 of that would
+    # overwhelm the response. Filtered bundles stay well under this.
+    MAX_BINARY_BYTES = 4_000_000
 
 
 class TmSearchFields:
     """Field names for the tmsearch.uspto.gov internal search index.
 
-    BEST-EFFORT SHAPE — NOT verified live. tmsearch.uspto.gov is the
-    undocumented internal API behind the USPTO trademark search web app
-    (TESS replacement). These names are drawn from public observations of
-    the web app's network calls and may change without notice. Confirm
-    against live traffic (browser dev tools on tmsearch.uspto.gov) before
-    relying on them; this class is the single place to fix names.
+    VERIFIED LIVE 2026-06-10 against POST /prod-stage-v1-0-0/tmsearch.
+    tmsearch.uspto.gov is the undocumented internal API behind the USPTO
+    trademark search web app (TESS replacement); it may still change
+    without notice. This class is the single place to fix names.
+
+    Notes from live verification:
+      - The index stores serial numbers in "id" (also echoed as the hit id).
+      - internationalClass values are stored as "IC 025"-style tokens, so
+        term filters must use zero-padded 3-digit class numbers ("025").
+      - Responses use {"hits": {"totalValue": N, "hits": [{"source": ...}]}}
+        (not the standard Elasticsearch total.value/_source envelope).
     """
     WORDMARK = "wordmark"
     OWNER = "ownerFullText"
     SERIAL_NUMBER = "id"
     REGISTRATION_NUMBER = "registrationId"
-    INTERNATIONAL_CLASS = "internationalClasses"
+    INTERNATIONAL_CLASS = "internationalClass"
     ALIVE = "alive"
     GOODS_AND_SERVICES = "goodsAndServices"
     MARK_TYPE = "markType"
     REGISTRATION_DATE = "registrationDate"
     ABANDON_DATE = "abandonDate"
+    STATUS_CODE = "statusCode"
+    STATUS_DESCRIPTION = "statusDescription"
 
 
 class OfficeActionTypes:

--- a/src/patent_mcp_server/patents.py
+++ b/src/patent_mcp_server/patents.py
@@ -1,18 +1,21 @@
 """
-USPTO Patent Search MCP Server
+USPTO Patent & Trademark Search MCP Server
 
 This file provides a Model Context Protocol (MCP) server that exposes tools for interacting
-with multiple USPTO patent data APIs:
+with multiple USPTO patent and trademark data APIs:
 
 1. ppubs.uspto.gov - Full text patent documents, PDF downloads, and advanced search
 2. api.uspto.gov - Metadata, continuity information, transactions, and assignments
 3. PTAB API v3 - Patent Trial and Appeal Board proceedings and decisions
-4. PatentsView API - UNAVAILABLE (shut down March 2026; data migrated to ODP bulk datasets)
-5. Office Action APIs - UNAVAILABLE (decommissioned early 2026, pending ODP migration)
+4. tsdrapi.uspto.gov - Trademark status, prosecution documents, and mark images (TSDR)
+5. tmsearch.uspto.gov - Full-text trademark search (internal API, TESS replacement)
+6. Trademark Assignment Search - ownership transfer records (ODP with legacy fallback)
+7. PatentsView API - UNAVAILABLE (shut down March 2026; data migrated to ODP bulk datasets)
+8. Office Action APIs - UNAVAILABLE (decommissioned early 2026, pending ODP migration)
 
 The server uses stdio transport for Claude Code/Cursor integration.
 
-Version: 0.9.5
+Version: 1.0.0
 """
 import atexit
 import json
@@ -28,7 +31,10 @@ from patent_mcp_server.constants import (
     Sources, Fields, Defaults, PatentsViewEndpoints
 )
 from patent_mcp_server.util.errors import ApiError, is_error
-from patent_mcp_server.util.validation import validate_patent_number, validate_app_number
+from patent_mcp_server.util.validation import (
+    validate_patent_number, validate_app_number,
+    validate_serial_number, validate_registration_number
+)
 from patent_mcp_server.util.response import (
     ResponseEnvelope, check_and_truncate, estimate_tokens
 )
@@ -36,18 +42,37 @@ from patent_mcp_server.resources import (
     get_cpc_section_info, get_cpc_subsection_info,
     get_status_code_info, get_all_status_codes,
     get_data_source_info, get_all_data_sources,
-    get_search_syntax_guide, CPC_SECTIONS, DATA_SOURCES
+    get_search_syntax_guide, CPC_SECTIONS, DATA_SOURCES,
+    get_trademark_class_info as resource_trademark_class_info,
+    get_trademark_status_code_info, get_all_trademark_classes,
+    get_all_trademark_status_codes
 )
 from patent_mcp_server.prompts import get_prompt, list_prompts, PROMPTS
 from patent_mcp_server.uspto.ppubs_uspto_gov import PpubsClient
 from patent_mcp_server.uspto.api_uspto_gov import ApiUsptoClient
 from patent_mcp_server.uspto.ptab_client import PTABClient
+from patent_mcp_server.uspto.tsdr_client import TSDRClient
+from patent_mcp_server.uspto.tmsearch_client import TmSearchClient
+from patent_mcp_server.uspto.tm_assignment_client import TmAssignmentClient
 from patent_mcp_server.uspto.office_action_client import OfficeActionClient
 from patent_mcp_server.uspto.enriched_citation_client import EnrichedCitationClient
 from patent_mcp_server.patentsview.patentsview_client import PatentsViewClient
 
 # Initialize FastMCP server
-mcp = FastMCP("uspto_patent_tools")
+mcp = FastMCP(
+    "uspto_patent_tools",
+    instructions=(
+        "Tools for researching US patents AND US federal trademarks. "
+        "Patents: full-text search and PDFs (ppubs_*), file-wrapper "
+        "metadata, assignments and continuity (odp_*), and PTAB "
+        "proceedings (ptab_*). Trademarks: live status, documents, and "
+        "mark images via TSDR (tsdr_*), full-text mark/owner search and "
+        "assignment history (tm_*). Reference lookups: get_cpc_info, "
+        "get_status_code, get_trademark_class_info, "
+        "get_trademark_status_code. Use check_api_status to see which "
+        "sources are configured and available."
+    ),
+)
 
 # Set up logging with configured level
 logging.basicConfig(
@@ -70,6 +95,11 @@ enriched_citation_client = EnrichedCitationClient()
 # Create PatentsView client
 patentsview_client = PatentsViewClient()
 
+# Create trademark clients
+tsdr_client = TSDRClient()
+tmsearch_client = TmSearchClient()
+tm_assignment_client = TmAssignmentClient()
+
 
 # Register cleanup handler
 async def cleanup():
@@ -82,6 +112,9 @@ async def cleanup():
         await office_action_client.close()
         await enriched_citation_client.close()
         await patentsview_client.close()
+        await tsdr_client.close()
+        await tmsearch_client.close()
+        await tm_assignment_client.close()
         logger.info("Cleanup completed successfully")
     except Exception as e:
         logger.error(f"Error during cleanup: {str(e)}")
@@ -182,9 +215,41 @@ async def resource_search_syntax() -> str:
     """Get search query syntax guide for all APIs.
 
     Returns documentation on query syntax for PPUBS, PatentsView,
-    and ODP APIs with examples.
+    ODP, and trademark search APIs with examples.
     """
     return get_search_syntax_guide()
+
+
+@mcp.resource("trademarks://classes")
+async def resource_trademark_classes() -> str:
+    """Get all Nice/international trademark classes.
+
+    Returns all 45 international classes (goods 1-34, services 35-45)
+    with titles and descriptions for trademark classification reference.
+    """
+    return json.dumps(get_all_trademark_classes(), indent=2)
+
+
+@mcp.resource("trademarks://classes/{number}")
+async def resource_trademark_class(number: str) -> str:
+    """Get a specific Nice/international trademark class definition."""
+    return json.dumps(resource_trademark_class_info(number), indent=2)
+
+
+@mcp.resource("trademarks://status-codes")
+async def resource_trademark_status_codes() -> str:
+    """Get USPTO trademark status code definitions.
+
+    Returns commonly encountered trademark status codes with
+    descriptions and prosecution stages.
+    """
+    return json.dumps(get_all_trademark_status_codes(), indent=2)
+
+
+@mcp.resource("trademarks://status-codes/{code}")
+async def resource_trademark_status_code(code: str) -> str:
+    """Get a specific USPTO trademark status code definition."""
+    return json.dumps(get_trademark_status_code_info(code), indent=2)
 
 
 # =====================================================================
@@ -251,6 +316,36 @@ async def patent_landscape() -> str:
     return get_prompt("patent_landscape")["content"]
 
 
+@mcp.prompt()
+async def trademark_clearance_search() -> str:
+    """Guide for trademark clearance (knockout) searching.
+
+    USE THIS PROMPT WHEN: You need to assess whether a proposed mark is
+    available by finding existing federal trademarks that could block it.
+    """
+    return get_prompt("trademark_clearance")["content"]
+
+
+@mcp.prompt()
+async def trademark_portfolio_review() -> str:
+    """Guide for reviewing a trademark portfolio.
+
+    USE THIS PROMPT WHEN: You need to inventory a company's trademarks,
+    check statuses and class coverage, and flag renewal deadlines.
+    """
+    return get_prompt("trademark_portfolio")["content"]
+
+
+@mcp.prompt()
+async def trademark_status_monitoring() -> str:
+    """Guide for monitoring trademark status and conflicts.
+
+    USE THIS PROMPT WHEN: You need to track application/registration status
+    over time or watch for new conflicting filings and oppositions.
+    """
+    return get_prompt("trademark_monitoring")["content"]
+
+
 # =====================================================================
 # Helper Functions
 # =====================================================================
@@ -303,7 +398,7 @@ async def _search_patent_by_number(patent_number: str) -> Dict[str, Any]:
 
 @mcp.tool()
 async def check_api_status() -> Dict[str, Any]:
-    """Check status and availability of all patent data sources.
+    """Check status and availability of all patent and trademark data sources.
 
     USE THIS TOOL WHEN: You encounter errors or want to verify which APIs
     are available and properly configured before starting research.
@@ -353,6 +448,48 @@ async def check_api_status() -> Dict[str, Any]:
                 "Legacy endpoints at developer.uspto.gov were decommissioned "
                 "in early 2026. Migration to ODP (api.uspto.gov) is pending. "
                 "Use odp_get_documents as a workaround."
+            ),
+        },
+        "tsdr": {
+            "name": "Trademark Status and Document Retrieval (TSDR)",
+            "configured": bool(config.TSDR_API_KEY),
+            "api_key_set": bool(config.TSDR_API_KEY),
+            "note": (
+                "Official trademark status/document API at tsdrapi.uspto.gov. "
+                "Requires an API key sent as the USPTO-API-KEY header "
+                "(TSDR_API_KEY env var, falls back to USPTO_API_KEY). Rate "
+                "limits: 60 req/min general, 4 req/min for PDF downloads."
+            ),
+        },
+        "tmsearch": {
+            "name": "Trademark Search (tmsearch.uspto.gov)",
+            "configured": True,
+            "requires_auth": False,
+            "note": (
+                "Undocumented internal API behind the USPTO trademark search "
+                "web app (TESS replacement) — same risk profile as PPUBS; "
+                "may change without notice. USPTO offers no official REST "
+                "API for full-text trademark search."
+            ),
+        },
+        "tm_assignments": {
+            "name": "Trademark Assignment Search",
+            "configured": bool(config.USPTO_API_KEY),
+            "api_key_set": bool(config.USPTO_API_KEY),
+            "note": (
+                "Tries the ODP endpoint (api.uspto.gov) first, falls back to "
+                "the legacy XML API at assignment-api.uspto.gov. Search "
+                "results report which backend answered."
+            ),
+        },
+        "ttab": {
+            "name": "Trademark Trial and Appeal Board (TTAB)",
+            "configured": False,
+            "status": "NOT_AVAILABLE_AS_API",
+            "note": (
+                "TTAB proceedings have no public REST API. Daily TTAB XML "
+                "data is published as bulk datasets on the Open Data Portal "
+                "— use odp_search_datasets to find them."
             ),
         },
         "litigation": {
@@ -587,7 +724,12 @@ async def ppubs_download_patent_pdf(patent_number: str) -> Dict[str, Any]:
         return search_result
 
     patent = search_result["patent"]
-    return await ppubs_client.download_image(patent[Fields.GUID], patent[Fields.TYPE])
+    return await ppubs_client.download_image(
+        patent[Fields.GUID],
+        patent[Fields.IMAGE_LOCATION],
+        patent[Fields.PAGE_COUNT],
+        patent[Fields.TYPE],
+    )
 
 
 # =====================================================================
@@ -1106,6 +1248,302 @@ async def ptab_get_appeal(appeal_number: str) -> Dict[str, Any]:
     if is_error(result):
         return result
     return check_and_truncate(ResponseEnvelope.from_ptab(result))
+
+
+# =====================================================================
+# TSDR Tools - Trademark Status and Document Retrieval
+# =====================================================================
+
+@mcp.tool()
+async def tsdr_get_trademark_status(
+    serial_number: Optional[str] = None,
+    registration_number: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get current status of a trademark application or registration from TSDR.
+
+    USE THIS TOOL WHEN: You have a trademark serial number or registration
+    number and need its authoritative live status, mark text, owner,
+    international classes, filing/registration dates, or prosecution stage.
+    TSDR is the official USPTO status source (requires API key).
+
+    Exactly one of serial_number or registration_number is required.
+
+    Args:
+        serial_number: 8-digit application serial number (e.g., "78787878")
+        registration_number: Registration number (e.g., "3500027")
+
+    Returns:
+        Normalized response with the trademark status record.
+    """
+    if serial_number:
+        try:
+            serial_number = validate_serial_number(str(serial_number))
+        except ValueError as e:
+            return ApiError.validation_error(str(e), "serial_number")
+    if registration_number:
+        try:
+            registration_number = validate_registration_number(str(registration_number))
+        except ValueError as e:
+            return ApiError.validation_error(str(e), "registration_number")
+
+    result = await tsdr_client.get_case_status(
+        serial_number=serial_number,
+        registration_number=registration_number,
+    )
+
+    if is_error(result):
+        return result
+
+    return check_and_truncate(ResponseEnvelope.from_tsdr(result))
+
+
+@mcp.tool()
+async def tsdr_download_trademark_documents(
+    serial_number: str,
+    document_type: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Download the prosecution document bundle for a trademark as PDF (base64).
+
+    USE THIS TOOL WHEN: You need office actions, responses, specimens, or
+    other file-wrapper documents for a trademark application.
+
+    NOTE: TSDR limits PDF downloads to 4 requests per minute per API key.
+    Filter by document_type and date range to keep bundles small.
+
+    Args:
+        serial_number: 8-digit application serial number (e.g., "78787878")
+        document_type: Optional document type filter (e.g., "OOA" for
+            outgoing office actions, "SPE" for specimens)
+        date_from: Optional start date filter (YYYY-MM-DD)
+        date_to: Optional end date filter (YYYY-MM-DD)
+
+    Returns:
+        Dictionary with base64-encoded PDF data.
+    """
+    try:
+        serial_number = validate_serial_number(str(serial_number))
+    except ValueError as e:
+        return ApiError.validation_error(str(e), "serial_number")
+
+    return await tsdr_client.download_case_documents(
+        serial_number=serial_number,
+        document_type=document_type,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+
+@mcp.tool()
+async def tsdr_get_trademark_image(serial_number: str) -> Dict[str, Any]:
+    """Get the mark image (drawing) for a trademark as base64.
+
+    USE THIS TOOL WHEN: You need the visual representation of a design mark
+    or stylized word mark.
+
+    Args:
+        serial_number: 8-digit application serial number (e.g., "78787878")
+
+    Returns:
+        Dictionary with base64-encoded image data.
+    """
+    try:
+        serial_number = validate_serial_number(str(serial_number))
+    except ValueError as e:
+        return ApiError.validation_error(str(e), "serial_number")
+
+    return await tsdr_client.get_mark_image(serial_number)
+
+
+# =====================================================================
+# Trademark Search & Assignment Tools
+# =====================================================================
+
+@mcp.tool()
+async def tm_search_trademarks(
+    query: Optional[str] = None,
+    mark_text: Optional[str] = None,
+    owner_name: Optional[str] = None,
+    international_class: Optional[str] = None,
+    status_filter: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 25,
+) -> Dict[str, Any]:
+    """Search US federal trademark applications and registrations.
+
+    USE THIS TOOL WHEN: You need to find trademarks by mark text, owner, or
+    Nice/international class — e.g. clearance/knockout searches for a
+    proposed mark, or mapping a company's trademark portfolio.
+
+    NOTE: Backed by the undocumented internal API behind tmsearch.uspto.gov
+    (the TESS replacement) — same risk profile as PPUBS; may break without
+    notice. For authoritative status of a specific mark, use
+    tsdr_get_trademark_status. Federal marks only (no common-law/state marks).
+
+    Args:
+        query: Raw query string for advanced searches
+        mark_text: Word mark text to search (e.g., "ACME")
+        owner_name: Owner/applicant name to search
+        international_class: Nice class number 1-45 (e.g., "9" for software;
+            use get_trademark_class_info to look up classes)
+        status_filter: "live" (active marks), "dead" (abandoned/cancelled/
+            expired), or omit for both
+        offset: Starting position for pagination (default: 0)
+        limit: Maximum results to return (default: 25, max: 100)
+
+    Returns:
+        Normalized response with matching trademark records.
+    """
+    if not any([query, mark_text, owner_name, international_class]):
+        return ApiError.create(
+            message=(
+                "At least one search filter is required. Provide query, "
+                "mark_text, owner_name, or international_class."
+            ),
+            error_code="MISSING_FILTER",
+        )
+
+    result = await tmsearch_client.search(
+        query=query,
+        mark_text=mark_text,
+        owner_name=owner_name,
+        international_class=international_class,
+        status_filter=status_filter,
+        offset=offset,
+        limit=limit,
+    )
+
+    if is_error(result):
+        return result
+
+    return check_and_truncate(
+        ResponseEnvelope.from_tmsearch(result, offset=offset, limit=limit)
+    )
+
+
+@mcp.tool()
+async def tm_get_trademark(serial_number: str) -> Dict[str, Any]:
+    """Get a trademark's search-index record by serial number.
+
+    USE THIS TOOL WHEN: You have a serial number from tm_search_trademarks
+    results and want the full indexed record. For authoritative live status,
+    prefer tsdr_get_trademark_status.
+
+    Args:
+        serial_number: 8-digit application serial number (e.g., "78787878")
+
+    Returns:
+        Normalized response with the trademark record.
+    """
+    try:
+        serial_number = validate_serial_number(str(serial_number))
+    except ValueError as e:
+        return ApiError.validation_error(str(e), "serial_number")
+
+    result = await tmsearch_client.get_by_serial(serial_number)
+
+    if is_error(result):
+        return result
+
+    if not result.get("results"):
+        return ApiError.not_found("Trademark", serial_number)
+
+    return check_and_truncate(
+        ResponseEnvelope.from_tmsearch(result, offset=0, limit=1)
+    )
+
+
+@mcp.tool()
+async def tm_search_assignments(
+    serial_number: Optional[str] = None,
+    registration_number: Optional[str] = None,
+    assignee_name: Optional[str] = None,
+    assignor_name: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 25,
+) -> Dict[str, Any]:
+    """Search recorded trademark assignment (ownership transfer) records.
+
+    USE THIS TOOL WHEN: You need to trace ownership history of a trademark,
+    find the current owner, or find marks transferred to/from a company.
+    Covers recorded assignments from 1955 to present.
+
+    At least one filter is required.
+
+    Args:
+        serial_number: Trademark application serial number
+        registration_number: Trademark registration number
+        assignee_name: Assignee (new owner) name
+        assignor_name: Assignor (previous owner) name
+        offset: Starting position for pagination (default: 0)
+        limit: Maximum results to return (default: 25)
+
+    Returns:
+        Normalized response with assignment records. The metadata reports
+        which backend answered ("odp" or "legacy").
+    """
+    if serial_number:
+        try:
+            serial_number = validate_serial_number(str(serial_number))
+        except ValueError as e:
+            return ApiError.validation_error(str(e), "serial_number")
+    if registration_number:
+        try:
+            registration_number = validate_registration_number(str(registration_number))
+        except ValueError as e:
+            return ApiError.validation_error(str(e), "registration_number")
+
+    result = await tm_assignment_client.search_assignments(
+        serial_number=serial_number,
+        registration_number=registration_number,
+        assignee_name=assignee_name,
+        assignor_name=assignor_name,
+        offset=offset,
+        limit=limit,
+    )
+
+    if is_error(result):
+        return result
+
+    return check_and_truncate(
+        ResponseEnvelope.from_tm_assignment(result, offset=offset, limit=limit)
+    )
+
+
+@mcp.tool()
+async def get_trademark_class_info(class_number: str) -> Dict[str, Any]:
+    """Look up a Nice/international trademark class (1-45).
+
+    USE THIS TOOL WHEN: You need to know what goods (classes 1-34) or
+    services (classes 35-45) a trademark class covers, or pick the right
+    classes for a clearance search.
+
+    Args:
+        class_number: International class number (e.g., "9" for computer
+            software, "25" for clothing, "42" for software services)
+
+    Returns:
+        Class title, type (goods/services), and description.
+    """
+    return resource_trademark_class_info(class_number)
+
+
+@mcp.tool()
+async def get_trademark_status_code(code: str) -> Dict[str, Any]:
+    """Look up a USPTO trademark status code meaning.
+
+    USE THIS TOOL WHEN: Trademark data contains a numeric status code you
+    need to interpret (e.g., "700" = Registered, "686" = Published for
+    opposition).
+
+    Args:
+        code: Trademark status code (e.g., "700")
+
+    Returns:
+        Status code description and prosecution stage.
+    """
+    return get_trademark_status_code_info(code)
 
 
 # =====================================================================
@@ -1849,7 +2287,7 @@ async def get_party_litigation(
 
 def main():
     """Initialize and run the server with stdio transport."""
-    logger.info("Starting USPTO Patent MCP server with stdio transport")
+    logger.info("Starting USPTO Patent & Trademark MCP server with stdio transport")
     mcp.run(transport='stdio')
 
 

--- a/src/patent_mcp_server/patents.py
+++ b/src/patent_mcp_server/patents.py
@@ -9,7 +9,7 @@ with multiple USPTO patent and trademark data APIs:
 3. PTAB API v3 - Patent Trial and Appeal Board proceedings and decisions
 4. tsdrapi.uspto.gov - Trademark status, prosecution documents, and mark images (TSDR)
 5. tmsearch.uspto.gov - Full-text trademark search (internal API, TESS replacement)
-6. Trademark Assignment Search - ownership transfer records (ODP with legacy fallback)
+6. assignmentcenter.uspto.gov - Trademark assignment (ownership transfer) records
 7. PatentsView API - UNAVAILABLE (shut down March 2026; data migrated to ODP bulk datasets)
 8. Office Action APIs - UNAVAILABLE (decommissioned early 2026, pending ODP migration)
 
@@ -456,9 +456,11 @@ async def check_api_status() -> Dict[str, Any]:
             "api_key_set": bool(config.TSDR_API_KEY),
             "note": (
                 "Official trademark status/document API at tsdrapi.uspto.gov. "
-                "Requires an API key sent as the USPTO-API-KEY header "
-                "(TSDR_API_KEY env var, falls back to USPTO_API_KEY). Rate "
-                "limits: 60 req/min general, 4 req/min for PDF downloads."
+                "Requires a TSDR-specific API key sent as the USPTO-API-KEY "
+                "header (TSDR_API_KEY env var). NOTE: the ODP key does NOT "
+                "work — it passes the gateway but every request 404s. Request "
+                "a TSDR key at account.uspto.gov/profile/api-manager. Rate "
+                "limits (peak): 60 req/min general, 4 req/min PDF downloads."
             ),
         },
         "tmsearch": {
@@ -468,18 +470,21 @@ async def check_api_status() -> Dict[str, Any]:
             "note": (
                 "Undocumented internal API behind the USPTO trademark search "
                 "web app (TESS replacement) — same risk profile as PPUBS; "
-                "may change without notice. USPTO offers no official REST "
-                "API for full-text trademark search."
+                "may change without notice. Contract verified live 2026-06-10. "
+                "Sits behind AWS WAF: if requests start failing with 403/202, "
+                "set TMSEARCH_WAF_TOKEN from a browser session cookie. USPTO "
+                "offers no official REST API for full-text trademark search."
             ),
         },
         "tm_assignments": {
-            "name": "Trademark Assignment Search",
-            "configured": bool(config.USPTO_API_KEY),
-            "api_key_set": bool(config.USPTO_API_KEY),
+            "name": "Trademark Assignment Search (Assignment Center)",
+            "configured": True,
+            "requires_auth": False,
             "note": (
-                "Tries the ODP endpoint (api.uspto.gov) first, falls back to "
-                "the legacy XML API at assignment-api.uspto.gov. Search "
-                "results report which backend answered."
+                "USPTO Assignment Center public API at "
+                "assignmentcenter.uspto.gov — no API key required. Verified "
+                "live 2026-06-10. Replaced the legacy assignment-api.uspto.gov "
+                "XML API, which was decommissioned June 5, 2026."
             ),
         },
         "ttab": {
@@ -1298,6 +1303,41 @@ async def tsdr_get_trademark_status(
 
 
 @mcp.tool()
+async def tsdr_list_trademark_documents(serial_number: str) -> Dict[str, Any]:
+    """List prosecution document metadata for a trademark (no downloads).
+
+    USE THIS TOOL WHEN: You want to see what file-wrapper documents exist
+    for a trademark application (office actions, responses, specimens,
+    registration certificates) before downloading anything. Unlike
+    tsdr_download_trademark_documents, this returns metadata only and is
+    NOT subject to the 4 req/min PDF rate limit. Use the DocumentTypeCode
+    values it returns (e.g. "OOA", "SPE") as the document_type filter when
+    downloading.
+
+    Args:
+        serial_number: 8-digit application serial number (e.g., "78787878")
+
+    Returns:
+        Document metadata records (type, description, dates).
+    """
+    try:
+        serial_number = validate_serial_number(str(serial_number))
+    except ValueError as e:
+        return ApiError.validation_error(str(e), "serial_number")
+
+    result = await tsdr_client.list_case_documents(serial_number)
+
+    if is_error(result):
+        return result
+
+    return check_and_truncate(ResponseEnvelope.success(
+        results=result.get("results", []),
+        source="tsdr",
+        total=result.get("total"),
+    ))
+
+
+@mcp.tool()
 async def tsdr_download_trademark_documents(
     serial_number: str,
     document_type: Optional[str] = None,
@@ -1309,8 +1349,10 @@ async def tsdr_download_trademark_documents(
     USE THIS TOOL WHEN: You need office actions, responses, specimens, or
     other file-wrapper documents for a trademark application.
 
-    NOTE: TSDR limits PDF downloads to 4 requests per minute per API key.
-    Filter by document_type and date range to keep bundles small.
+    NOTE: TSDR limits PDF downloads to 4 requests per minute per API key,
+    and unfiltered full wrappers can exceed 10 MB (rejected with
+    RESPONSE_TOO_LARGE above 4 MB). Call tsdr_list_trademark_documents
+    first, then filter by document_type and/or date range.
 
     Args:
         serial_number: 8-digit application serial number (e.g., "78787878")
@@ -1365,6 +1407,8 @@ async def tm_search_trademarks(
     query: Optional[str] = None,
     mark_text: Optional[str] = None,
     owner_name: Optional[str] = None,
+    goods_services: Optional[str] = None,
+    registration_number: Optional[str] = None,
     international_class: Optional[str] = None,
     status_filter: Optional[str] = None,
     offset: int = 0,
@@ -1372,9 +1416,10 @@ async def tm_search_trademarks(
 ) -> Dict[str, Any]:
     """Search US federal trademark applications and registrations.
 
-    USE THIS TOOL WHEN: You need to find trademarks by mark text, owner, or
-    Nice/international class — e.g. clearance/knockout searches for a
-    proposed mark, or mapping a company's trademark portfolio.
+    USE THIS TOOL WHEN: You need to find trademarks by mark text, owner,
+    goods/services description, or Nice/international class — e.g.
+    clearance/knockout searches for a proposed mark, or mapping a company's
+    trademark portfolio.
 
     NOTE: Backed by the undocumented internal API behind tmsearch.uspto.gov
     (the TESS replacement) — same risk profile as PPUBS; may break without
@@ -1385,6 +1430,9 @@ async def tm_search_trademarks(
         query: Raw query string for advanced searches
         mark_text: Word mark text to search (e.g., "ACME")
         owner_name: Owner/applicant name to search
+        goods_services: Goods/services description terms (e.g., "athletic
+            footwear") — useful for clearance searches across wording
+        registration_number: Exact registration number to look up
         international_class: Nice class number 1-45 (e.g., "9" for software;
             use get_trademark_class_info to look up classes)
         status_filter: "live" (active marks), "dead" (abandoned/cancelled/
@@ -1395,19 +1443,29 @@ async def tm_search_trademarks(
     Returns:
         Normalized response with matching trademark records.
     """
-    if not any([query, mark_text, owner_name, international_class]):
+    if not any([query, mark_text, owner_name, goods_services,
+                registration_number, international_class]):
         return ApiError.create(
             message=(
                 "At least one search filter is required. Provide query, "
-                "mark_text, owner_name, or international_class."
+                "mark_text, owner_name, goods_services, registration_number, "
+                "or international_class."
             ),
             error_code="MISSING_FILTER",
         )
+
+    if registration_number:
+        try:
+            registration_number = validate_registration_number(str(registration_number))
+        except ValueError as e:
+            return ApiError.validation_error(str(e), "registration_number")
 
     result = await tmsearch_client.search(
         query=query,
         mark_text=mark_text,
         owner_name=owner_name,
+        goods_services=goods_services,
+        registration_number=registration_number,
         international_class=international_class,
         status_filter=status_filter,
         offset=offset,
@@ -1460,6 +1518,7 @@ async def tm_search_assignments(
     registration_number: Optional[str] = None,
     assignee_name: Optional[str] = None,
     assignor_name: Optional[str] = None,
+    reel_frame: Optional[str] = None,
     offset: int = 0,
     limit: int = 25,
 ) -> Dict[str, Any]:
@@ -1467,21 +1526,23 @@ async def tm_search_assignments(
 
     USE THIS TOOL WHEN: You need to trace ownership history of a trademark,
     find the current owner, or find marks transferred to/from a company.
-    Covers recorded assignments from 1955 to present.
+    Covers recorded assignments from 1955 to present, via the USPTO
+    Assignment Center public API (no API key required).
 
-    At least one filter is required.
+    At least one filter is required; multiple filters combine (AND).
 
     Args:
         serial_number: Trademark application serial number
         registration_number: Trademark registration number
         assignee_name: Assignee (new owner) name
         assignor_name: Assignor (previous owner) name
+        reel_frame: Recordation reel/frame identifier (e.g., "9006/0093")
         offset: Starting position for pagination (default: 0)
         limit: Maximum results to return (default: 25)
 
     Returns:
-        Normalized response with assignment records. The metadata reports
-        which backend answered ("odp" or "legacy").
+        Normalized response with assignment records (reel/frame, assignors,
+        assignees, conveyance, and affected properties).
     """
     if serial_number:
         try:
@@ -1499,6 +1560,7 @@ async def tm_search_assignments(
         registration_number=registration_number,
         assignee_name=assignee_name,
         assignor_name=assignor_name,
+        reel_frame=reel_frame,
         offset=offset,
         limit=limit,
     )

--- a/src/patent_mcp_server/prompts.py
+++ b/src/patent_mcp_server/prompts.py
@@ -479,12 +479,15 @@ Likelihood of confusion extends beyond exact matches. Search separately for:
 - Translations of foreign-word marks (doctrine of foreign equivalents)
 - The dominant word in compound marks
 
-## Step 4: Narrow by Class
+## Step 4: Narrow by Class and Goods/Services
 ```
 Use tm_search_trademarks with international_class:
 - Focus on the classes identified in Step 1
 - Also check related/complementary classes (e.g., class 9 software
   vs class 42 software services)
+Use tm_search_trademarks with goods_services:
+- Search the actual goods/services wording (e.g., "athletic footwear")
+  to catch marks classified differently than expected
 ```
 
 ## Step 5: Verify Status of Close Hits
@@ -504,10 +507,12 @@ Use tm_search_trademarks with owner_name:
 
 ## Step 7: Review Documents if Needed
 ```
-Use tsdr_download_trademark_documents:
+Use tsdr_list_trademark_documents first:
+- See what file-wrapper documents exist (metadata only, no rate limit)
+Then tsdr_download_trademark_documents for the ones you need:
 - Examine specimens to see how a mark is actually used
 - Review office actions for examiner views on similar marks
-(Rate limited to 4 PDF downloads/minute.)
+(PDF downloads rate limited to 4/minute.)
 ```
 
 ## Important Caveats:
@@ -601,10 +606,12 @@ Key transitions to watch for:
 
 ## Step 4: Pull New Documents
 ```
-Use tsdr_download_trademark_documents when status changes:
+Use tsdr_list_trademark_documents when status changes:
+- Check what new documents arrived (metadata only, no PDF rate limit)
+Then tsdr_download_trademark_documents for the documents you need:
 - Filter by date_from to get only new documents
 - Office actions, examiner amendments, suspension notices
-(Rate limited to 4 PDF downloads/minute.)
+(PDF downloads rate limited to 4/minute.)
 ```
 
 ## Step 5: Watch for Oppositions

--- a/src/patent_mcp_server/prompts.py
+++ b/src/patent_mcp_server/prompts.py
@@ -1,8 +1,8 @@
 """
-MCP Prompts for USPTO Patent Server.
+MCP Prompts for USPTO Patent & Trademark Server.
 
-Prompts provide reusable workflow templates for common patent research tasks.
-Users can access these via / commands.
+Prompts provide reusable workflow templates for common patent and trademark
+research tasks. Users can access these via / commands.
 """
 
 PRIOR_ART_SEARCH_PROMPT = """
@@ -20,46 +20,47 @@ relevant to an invention. Follow this structured approach:
 Start with broad text searches to understand the landscape:
 
 ```
-Use patentsview_search_patents or ppubs_search_patents:
+Use ppubs_search_patents and ppubs_search_applications:
 - Search key terms from the invention description
 - Try synonyms and alternative phrasings
-- Use search_type="any" for broad results first
+- Quote phrases that must appear together (terms are AND-ed by default)
 ```
 
 ## Step 3: Identify Relevant CPC Codes
 From initial results, identify CPC classification codes:
 
 ```
-Use patentsview_lookup_cpc to understand classifications:
+Use get_cpc_info to understand classifications:
 - Note CPC codes from relevant patents found
-- Look up parent/child codes for broader/narrower scope
+- Look up section/subsection meanings for broader/narrower scope
 ```
 
 ## Step 4: CPC-Based Search (Focused)
 Search within relevant CPC classifications:
 
 ```
-Use patentsview_search_by_cpc:
-- Focus on identified CPC codes
-- Combine with keywords if needed
+Use ppubs_search_patents with CPC field qualifiers:
+- CPC/G06N3/08 - search a specific classification
+- Combine with keywords: CPC/G06N AND "transformer"
 ```
 
 ## Step 5: Inventor/Assignee Search
 Find patents from key players in the field:
 
 ```
-Use patentsview_search_inventors and patentsview_search_assignees:
-- Search for prolific inventors in the field
-- Find competitors' patent portfolios
+Use ppubs_search_patents with IN/ and AN/ qualifiers:
+- IN/Smith - patents by inventor Smith
+- AN/"International Business Machines" - assignee search
 ```
 
-## Step 6: Citation Analysis
+## Step 6: Examiner Citation Review
 Review what prior art examiners have cited:
 
 ```
-Use get_office_action_citations:
-- Check citations from related applications
+Use odp_get_documents on related applications:
+- Office actions in the file wrapper list cited references
 - Follow citation chains backward and forward
+(Note: the dedicated citation APIs were decommissioned in early 2026.)
 ```
 
 ## Step 7: International Coverage
@@ -74,8 +75,8 @@ Use ppubs_search_patents for PCT applications published in US:
 ## Tips:
 - Document all searches performed for completeness
 - Save relevant patent numbers for detailed review
-- Check patent family relationships with get_app_continuity
-- Review full claims using patentsview_get_claims
+- Check patent family relationships with odp_get_continuity
+- Review full claims using ppubs_get_full_document
 """
 
 PATENT_VALIDITY_ANALYSIS_PROMPT = """
@@ -85,7 +86,7 @@ Analyze the validity and prosecution history of a patent to assess its strength.
 
 ## Step 1: Get Patent Details
 ```
-Use ppubs_get_patent_by_number or patentsview_get_patent:
+Use ppubs_get_patent_by_number:
 - Review claims (especially independent claims)
 - Note the filing and priority dates
 - Identify the assignee and inventors
@@ -93,7 +94,7 @@ Use ppubs_get_patent_by_number or patentsview_get_patent:
 
 ## Step 2: Review Claims
 ```
-Use patentsview_get_claims:
+Use ppubs_get_full_document:
 - Identify independent vs dependent claims
 - Note claim scope and key limitations
 - Look for potential narrow vs broad interpretations
@@ -101,7 +102,7 @@ Use patentsview_get_claims:
 
 ## Step 3: Examine Prosecution History
 ```
-Use get_app (with application number) to get file wrapper data:
+Use odp_get_application (with application number) to get file wrapper data:
 - Review office action history
 - Check amendments made during prosecution
 - Note any disclaimer or terminal disclaimers
@@ -109,10 +110,11 @@ Use get_app (with application number) to get file wrapper data:
 
 ## Step 4: Review Office Actions
 ```
-Use get_office_action_text and get_office_action_rejections:
-- See what prior art examiner cited
-- Understand rejection bases (102, 103, 112)
+Use odp_get_documents and odp_get_transactions:
+- Find office action documents in the file wrapper
+- Understand rejection bases (102, 103, 112) from the documents
 - Review applicant's arguments and claim amendments
+(Note: the dedicated Office Action APIs were decommissioned in early 2026.)
 ```
 
 ## Step 5: Check PTAB Proceedings
@@ -125,23 +127,22 @@ Use ptab_search_proceedings with the patent number:
 
 ## Step 6: Review Litigation History
 ```
-Use get_patent_litigation_history:
-- Check for past infringement suits
-- Review outcomes and claim construction rulings
-- Note any settlements or licensing
+Patent litigation data is not available via API. The OCE Patent
+Litigation dataset (74,000+ district court cases) is a bulk download:
+https://www.uspto.gov/ip-policy/economic-research/research-datasets/patent-litigation-docket-reports-data
 ```
 
 ## Step 7: Citation Analysis
 ```
-Use get_enriched_citations:
-- Review forward citations (indicator of importance)
-- Check backward citations for prior art
-- Analyze citation metrics
+Use ppubs_get_full_document:
+- Review references cited on the face of the patent
+- Search forward citations with ppubs_search_patents
+(Note: the Enriched Citation API was decommissioned in early 2026.)
 ```
 
 ## Step 8: Family Analysis
 ```
-Use get_app_continuity:
+Use odp_get_continuity:
 - Identify parent/child applications
 - Check for continuation claim variations
 - Note any related patents with different claim scope
@@ -162,58 +163,56 @@ Analyze a company's patent portfolio to understand their IP position and strateg
 ## Step 1: Identify Company Variations
 Companies often file under different names:
 ```
-Use patentsview_search_assignees:
-- Search for company name and variations
+Use ppubs_search_patents with AN/ qualifier:
+- Search for company name and variations: AN/"Acme" OR AN/"Acme Corp"
 - Note subsidiary names
-- Record disambiguated assignee IDs
+- Also try odp_search_applications with assignee_name
 ```
 
 ## Step 2: Get Portfolio Overview
 ```
-Use patentsview_search with assignee filter:
-- Get count of total patents
-- Identify date range of filings
-- Note technology distribution by CPC
+Use ppubs_search_patents with assignee filter:
+- Get count of total patents (check the "total" field)
+- Identify date range of filings with ISD/ ranges
+- Note technology distribution by CPC codes in results
 ```
 
 ## Step 3: Technology Focus Analysis
 ```
-Use patentsview_search_by_cpc:
+Use ppubs_search_patents combining AN/ and CPC/ qualifiers:
 - Identify top CPC codes in portfolio
-- Map technology areas covered
+- Map technology areas covered (interpret with get_cpc_info)
 - Find gaps or emerging focus areas
 ```
 
 ## Step 4: Inventor Analysis
 ```
-Use patentsview_search_inventors:
-- Identify key inventors
+Use ppubs_search_patents with IN/ qualifier:
+- Identify key inventors appearing in results
 - Track inventor movement (acquired talent)
-- Find prolific inventors by patent count
 ```
 
 ## Step 5: Filing Trends
 ```
 Search with date filters:
-- Analyze year-over-year filing trends
+- Analyze year-over-year filing trends (ISD/ ranges)
 - Identify ramp-up or slow-down periods
 - Correlate with business events if known
 ```
 
-## Step 6: Citation Analysis
+## Step 6: Trademark Portfolio
 ```
-Use get_enriched_citations on key patents:
-- Identify most-cited patents (crown jewels)
-- Find citation relationships with competitors
-- Analyze technology influence
+Use tm_search_trademarks with owner_name:
+- Map the company's brand portfolio alongside its patents
+- Filter status_filter="live" for active marks
+- Check assignment history with tm_search_assignments
 ```
 
 ## Step 7: Litigation Profile
 ```
-Use get_party_litigation_history:
-- Review assertion history (offensive use)
-- Check defense cases (being sued)
-- Identify frequent opponents
+Patent litigation data is not available via API. Use the OCE Patent
+Litigation bulk dataset for assertion/defense history:
+https://www.uspto.gov/ip-policy/economic-research/research-datasets/patent-litigation-docket-reports-data
 ```
 
 ## Step 8: PTAB Exposure
@@ -228,6 +227,7 @@ Use ptab_search_proceedings with party name:
 - Total patent count and active patents
 - Top technology areas (by CPC)
 - Key patents (high citations, litigated)
+- Trademark/brand portfolio summary
 - Filing trend analysis
 - Risk areas (PTAB challenges, invalidations)
 """
@@ -262,7 +262,7 @@ Use ptab_get_proceeding:
 
 ## Step 3: Review Documents
 ```
-Use ptab_get_proceeding_documents:
+Use ptab_get_documents:
 - Get petition and patent owner response
 - Review expert declarations
 - Find settlement documents if terminated
@@ -319,7 +319,7 @@ Assess the risk of patent infringement for a product or technology.
 
 ## Step 2: Keyword and Classification Search
 ```
-Use patentsview_search and patentsview_search_by_cpc:
+Use ppubs_search_patents with keywords and CPC/ qualifiers:
 - Search for each technical feature
 - Use multiple synonyms and phrasings
 - Focus on relevant CPC classifications
@@ -333,7 +333,7 @@ For each patent found, evaluate:
 
 ## Step 4: Detailed Claim Analysis
 ```
-Use patentsview_get_claims and ppubs_get_patent_by_number:
+Use ppubs_get_full_document and ppubs_get_patent_by_number:
 - Read independent claims carefully
 - Compare each claim element to your product
 - Document any differences (design-arounds)
@@ -341,7 +341,7 @@ Use patentsview_get_claims and ppubs_get_patent_by_number:
 
 ## Step 5: Check Patent Status
 ```
-Use get_app_metadata and get_app_transactions:
+Use odp_get_application_metadata and odp_get_transactions:
 - Verify patent is not expired
 - Check for maintenance fee status
 - Note any terminal disclaimers
@@ -349,8 +349,8 @@ Use get_app_metadata and get_app_transactions:
 
 ## Step 6: Review Prosecution History
 ```
-Use get_office_action_text and get_office_action_rejections:
-- Understand scope limitations from prosecution
+Use odp_get_documents:
+- Find office actions in the file wrapper
 - Note any estoppel from claim amendments
 - Review applicant's arguments for claim interpretation
 ```
@@ -365,10 +365,9 @@ Use ptab_search_proceedings:
 
 ## Step 8: Assess Litigation History
 ```
-Use get_patent_litigation_history:
-- Check if patent has been asserted
-- Review claim construction rulings
-- Note any licenses or settlements
+Patent litigation data is not available via API. Use the OCE Patent
+Litigation bulk dataset:
+https://www.uspto.gov/ip-policy/economic-research/research-datasets/patent-litigation-docket-reports-data
 ```
 
 ## Risk Assessment Categories:
@@ -395,7 +394,7 @@ Map the patent landscape for a technology area to understand the competitive env
 
 ## Step 2: Identify Key CPC Classifications
 ```
-Use patentsview_lookup_cpc:
+Use get_cpc_info:
 - Find relevant CPC codes
 - Map hierarchical relationships
 - Note any cross-cutting codes
@@ -403,15 +402,15 @@ Use patentsview_lookup_cpc:
 
 ## Step 3: Quantitative Analysis
 ```
-Use patentsview_search_by_cpc with large limits:
-- Count total patents per CPC code
-- Track filings over time
+Use ppubs_search_patents with CPC/ qualifiers:
+- Check the "total" field for patents per CPC code
+- Track filings over time with ISD/ date ranges
 - Identify growth trends
 ```
 
 ## Step 4: Top Assignee Analysis
 ```
-Use patentsview_search_assignees:
+Use ppubs_search_patents combining CPC/ and AN/ qualifiers:
 - Rank companies by patent count
 - Calculate market share of filings
 - Identify new entrants vs incumbents
@@ -419,7 +418,7 @@ Use patentsview_search_assignees:
 
 ## Step 5: Geographic Distribution
 ```
-Use patentsview_search_patents with assignee filters:
+Use ppubs_search_patents with assignee filters:
 - Compare filing volumes by assignee location
 - Identify regional leaders among US filers
 - Note PCT (WO) filing trends via ppubs_search_applications
@@ -431,12 +430,12 @@ Group patents into sub-categories:
 - By claim feature keywords
 - By application type (method, system, composition)
 
-## Step 7: Citation Network Analysis
+## Step 7: Key Patent Identification
 ```
-Use get_enriched_citations:
-- Identify highly-cited foundational patents
-- Map citation relationships
-- Find technology leaders by citation metrics
+Use ppubs_get_full_document on candidate patents:
+- Identify foundational patents by references cited
+- Search forward citations with ppubs_search_patents
+(Note: the Enriched Citation API was decommissioned in early 2026.)
 ```
 
 ## Step 8: White Space Analysis
@@ -452,6 +451,179 @@ Identify underserved areas:
 - Geographic distribution
 - Key/seminal patents
 - White space opportunities
+"""
+
+TRADEMARK_CLEARANCE_SEARCH_PROMPT = """
+# Trademark Clearance (Knockout) Search Workflow
+
+Assess whether a proposed mark is available for use and registration by
+finding existing marks that could block it.
+
+## Step 1: Define the Proposed Mark
+- The exact mark text (and any design elements)
+- The goods/services it will cover
+- Identify relevant Nice classes with get_trademark_class_info
+  (goods are classes 1-34, services 35-45)
+
+## Step 2: Identical-Mark Knockout Search
+```
+Use tm_search_trademarks:
+- mark_text=<exact proposed mark>, status_filter="live"
+- An identical live mark in the same class is a strong blocker
+```
+
+## Step 3: Variant Searches
+Likelihood of confusion extends beyond exact matches. Search separately for:
+- Phonetic equivalents (e.g., "KWIK" for "QUICK", "XPRESS" for "EXPRESS")
+- Alternative spellings and plurals
+- Translations of foreign-word marks (doctrine of foreign equivalents)
+- The dominant word in compound marks
+
+## Step 4: Narrow by Class
+```
+Use tm_search_trademarks with international_class:
+- Focus on the classes identified in Step 1
+- Also check related/complementary classes (e.g., class 9 software
+  vs class 42 software services)
+```
+
+## Step 5: Verify Status of Close Hits
+```
+Use tsdr_get_trademark_status on each concerning mark:
+- Confirm live/dead status and registration details (TSDR is authoritative)
+- Interpret status codes with get_trademark_status_code
+- Note filing basis, dates, and goods/services descriptions
+```
+
+## Step 6: Investigate Owners of Blocking Marks
+```
+Use tm_search_trademarks with owner_name:
+- See the owner's full portfolio (aggressive filers may oppose)
+- Check ownership transfers with tm_search_assignments
+```
+
+## Step 7: Review Documents if Needed
+```
+Use tsdr_download_trademark_documents:
+- Examine specimens to see how a mark is actually used
+- Review office actions for examiner views on similar marks
+(Rate limited to 4 PDF downloads/minute.)
+```
+
+## Important Caveats:
+- This search covers US **federal** applications/registrations only
+- Common-law (unregistered) and state-registered marks are NOT covered
+- Likelihood of confusion is a legal judgment (similarity of marks,
+  relatedness of goods, trade channels) — flag close calls for counsel
+"""
+
+TRADEMARK_PORTFOLIO_REVIEW_PROMPT = """
+# Trademark Portfolio Review Workflow
+
+Review a company's trademark portfolio for status, coverage, and deadlines.
+
+## Step 1: Find the Portfolio
+```
+Use tm_search_trademarks with owner_name:
+- Search the company name and known variations/subsidiaries
+- Run once without status_filter to capture dead marks too
+```
+
+## Step 2: Check Status of Each Mark
+```
+Use tsdr_get_trademark_status for each mark of interest:
+- Current status and prosecution stage
+- Registration and renewal dates
+- Goods/services and classes covered
+```
+
+## Step 3: Map Class Coverage
+```
+Use get_trademark_class_info:
+- Tabulate which Nice classes the portfolio covers
+- Identify gaps versus the company's actual products/services
+```
+
+## Step 4: Renewal Deadline Awareness
+From TSDR dates, flag upcoming maintenance windows:
+- **Section 8 declaration of use**: between the 5th and 6th year after
+  registration (with a 6-month grace period)
+- **Section 8 & 9 renewal**: every 10 years after registration
+- Marks past these windows without filings risk cancellation
+  (status codes 710/900 — interpret with get_trademark_status_code)
+
+## Step 5: Ownership Verification
+```
+Use tm_search_assignments:
+- Confirm recorded chain of title for key marks
+- Find any unrecorded transfers (gaps in the chain)
+- Search by registration_number for specific marks
+```
+
+## Step 6: Spot Risks
+- Marks published for opposition (status 686) — opposition window open
+- Office actions outstanding — pull with tsdr_download_trademark_documents
+- Abandoned applications (status 602/604/606/608) for brands still in use
+
+## Deliverables:
+- Inventory of live marks with classes and renewal dates
+- Gap analysis (unprotected brands or classes)
+- Deadline calendar (Section 8/9 windows)
+- Chain-of-title issues
+"""
+
+TRADEMARK_STATUS_MONITORING_PROMPT = """
+# Trademark Status Monitoring Workflow
+
+Track the status of trademark applications and registrations over time —
+your own filings or marks you are watching.
+
+## Step 1: Establish the Watch List
+- Collect serial numbers (applications) and registration numbers
+- For competitor watching, find marks with tm_search_trademarks
+  (mark_text or owner_name)
+
+## Step 2: Pull Current Status
+```
+Use tsdr_get_trademark_status for each watched mark:
+- Record the status code and date
+- Interpret codes with get_trademark_status_code
+  (e.g., 630 new, 686 published for opposition, 700 registered)
+```
+
+## Step 3: Interpret Stage Transitions
+Key transitions to watch for:
+- **Examination → Office action** (640/644): response deadline running
+  (generally 3 months, extendable)
+- **Published for opposition** (686): 30-day opposition window opens
+- **Notice of allowance** (688): statement of use deadline running (ITU)
+- **Registered** (700): calendar Section 8/9 maintenance windows
+
+## Step 4: Pull New Documents
+```
+Use tsdr_download_trademark_documents when status changes:
+- Filter by date_from to get only new documents
+- Office actions, examiner amendments, suspension notices
+(Rate limited to 4 PDF downloads/minute.)
+```
+
+## Step 5: Watch for Oppositions
+TTAB proceedings (oppositions/cancellations) have no REST API:
+- Case status and filings: TTABVUE web interface
+- Bulk monitoring: daily TTAB XML datasets via odp_search_datasets
+
+## Step 6: Watch for New Conflicting Filings
+```
+Periodically re-run tm_search_trademarks:
+- mark_text variants of your marks, status_filter="live"
+- New applications similar to watched marks may warrant opposition
+  (file within the 30-day window after publication)
+```
+
+## Tips:
+- TSDR is the authoritative status source; search-index data may lag
+- Log status snapshots with dates to build a timeline
+- Escalate close conflicts and approaching deadlines to counsel
 """
 
 # Map of prompt names to content
@@ -485,6 +657,21 @@ PROMPTS = {
         "name": "Patent Landscape Analysis",
         "description": "Guide for mapping a technology patent landscape",
         "content": PATENT_LANDSCAPE_PROMPT,
+    },
+    "trademark_clearance": {
+        "name": "Trademark Clearance Search",
+        "description": "Guide for clearance/knockout searching of a proposed mark",
+        "content": TRADEMARK_CLEARANCE_SEARCH_PROMPT,
+    },
+    "trademark_portfolio": {
+        "name": "Trademark Portfolio Review",
+        "description": "Guide for reviewing a trademark portfolio and deadlines",
+        "content": TRADEMARK_PORTFOLIO_REVIEW_PROMPT,
+    },
+    "trademark_monitoring": {
+        "name": "Trademark Status Monitoring",
+        "description": "Guide for monitoring trademark status and watching for conflicts",
+        "content": TRADEMARK_STATUS_MONITORING_PROMPT,
     },
 }
 

--- a/src/patent_mcp_server/resources.py
+++ b/src/patent_mcp_server/resources.py
@@ -472,15 +472,17 @@ DATA_SOURCES = {
         "description": (
             "Official API for live trademark case status, prosecution "
             "documents, and mark images, keyed by serial or registration "
-            "number. Requires an API key sent as the USPTO-API-KEY header "
-            "(TSDR_API_KEY env var, falls back to USPTO_API_KEY)."
+            "number. Requires a TSDR-specific API key sent as the "
+            "USPTO-API-KEY header (TSDR_API_KEY env var). The ODP key does "
+            "NOT work — request a TSDR key at "
+            "account.uspto.gov/profile/api-manager ('TSDR API' product)."
         ),
         "coverage": {
             "status": "Live status for all US trademark applications and registrations",
-            "documents": "Prosecution history document bundles (PDF)",
+            "documents": "Prosecution document metadata and PDF bundles",
             "images": "Mark drawings/images",
         },
-        "rate_limits": "60 requests/min general; 4 requests/min for PDF/ZIP downloads (per API key)",
+        "rate_limits": "Peak (5am-10pm ET): 60 requests/min general, 4 requests/min PDF/ZIP; off-peak: 120/12 (per API key)",
         "auth_required": True,
         "best_for": [
             "Authoritative live status of a specific trademark",
@@ -496,38 +498,43 @@ DATA_SOURCES = {
             "Full-text trademark search via the undocumented internal API "
             "behind the USPTO trademark search web app (the TESS "
             "replacement). Same risk profile as PPUBS: not an official "
-            "public API and may change without notice. USPTO offers no "
-            "official REST API for full-text trademark search."
+            "public API and may change without notice (contract verified "
+            "live 2026-06-10). Sits behind AWS WAF — if requests start "
+            "failing with 403/202, set TMSEARCH_WAF_TOKEN from a browser "
+            "session cookie. USPTO offers no official REST API for "
+            "full-text trademark search."
         ),
         "coverage": {
-            "trademarks": "US federal trademark applications and registrations, searchable by mark text, owner, and class",
+            "trademarks": "US federal trademark applications and registrations, searchable by mark text, owner, goods/services, and class",
         },
         "rate_limits": "Undocumented, but throttled for heavy usage",
         "auth_required": False,
         "best_for": [
             "Clearance/knockout searches for a proposed mark",
-            "Finding marks by owner name",
+            "Finding marks by owner name or goods/services wording",
             "Filtering by Nice international class and live/dead status",
         ],
     },
     "tm_assignments": {
-        "name": "USPTO Trademark Assignment Search",
-        "base_url": "https://api.uspto.gov (legacy fallback: https://assignment-api.uspto.gov)",
+        "name": "USPTO Trademark Assignment Search (Assignment Center)",
+        "base_url": "https://assignmentcenter.uspto.gov",
         "description": (
             "Recorded trademark assignment (ownership transfer) records, "
-            "1955-present. The legacy assignment-api.uspto.gov service was "
-            "migrated to the Open Data Portal around April 2026; the client "
-            "tries ODP first and falls back to the legacy XML API."
+            "1955-present, via the USPTO Assignment Center public API "
+            "(verified live 2026-06-10; no API key required). Replaced the "
+            "legacy assignment-api.uspto.gov XML API, decommissioned with "
+            "the Developer Hub on June 5, 2026."
         ),
         "coverage": {
             "assignments": "Recorded trademark assignments from 1955 to present",
         },
-        "rate_limits": "Standard ODP rate limits on the ODP backend",
-        "auth_required": True,
+        "rate_limits": "Not published",
+        "auth_required": False,
         "best_for": [
             "Tracing trademark ownership history",
             "Finding marks assigned to or from a company",
             "Due diligence on trademark transfers",
+            "Looking up a recordation by reel/frame",
         ],
     },
     "ttab": {

--- a/src/patent_mcp_server/resources.py
+++ b/src/patent_mcp_server/resources.py
@@ -246,6 +246,92 @@ STATUS_CODES = {
     "82": {"description": "Continuation-in-Part Application Filed", "stage": "continuity"},
 }
 
+# Nice Classification - International trademark classes (goods 1-34, services 35-45)
+NICE_CLASSES = {
+    "1": {"title": "Chemicals", "type": "goods", "description": "Chemicals for industry, science, photography, agriculture; unprocessed plastics; fertilizers; adhesives for industry"},
+    "2": {"title": "Paints", "type": "goods", "description": "Paints, varnishes, lacquers; preservatives against rust; colorants, dyes; raw natural resins; printing inks"},
+    "3": {"title": "Cosmetics and Cleaning Preparations", "type": "goods", "description": "Cleaning, polishing and abrasive preparations; soaps; perfumery, essential oils, cosmetics, hair lotions; dentifrices"},
+    "4": {"title": "Lubricants and Fuels", "type": "goods", "description": "Industrial oils and greases; lubricants; fuels and illuminants; candles and wicks"},
+    "5": {"title": "Pharmaceuticals", "type": "goods", "description": "Pharmaceutical and veterinary preparations; sanitary preparations; dietetic food and supplements; plasters; disinfectants"},
+    "6": {"title": "Metal Goods", "type": "goods", "description": "Common metals and their alloys; metal building materials; pipes and tubes of metal; small items of metal hardware"},
+    "7": {"title": "Machinery", "type": "goods", "description": "Machines and machine tools; motors and engines (except for land vehicles); agricultural implements; vending machines"},
+    "8": {"title": "Hand Tools", "type": "goods", "description": "Hand tools and implements (hand-operated); cutlery; side arms; razors"},
+    "9": {"title": "Electrical and Scientific Apparatus", "type": "goods", "description": "Scientific, measuring, signalling apparatus; computers and computer software; data processing equipment; recorded media"},
+    "10": {"title": "Medical Apparatus", "type": "goods", "description": "Surgical, medical, dental and veterinary apparatus and instruments; artificial limbs; orthopedic articles; suture materials"},
+    "11": {"title": "Environmental Control Apparatus", "type": "goods", "description": "Apparatus for lighting, heating, steam generating, cooking, refrigerating, drying, ventilating, water supply and sanitary purposes"},
+    "12": {"title": "Vehicles", "type": "goods", "description": "Vehicles; apparatus for locomotion by land, air or water"},
+    "13": {"title": "Firearms", "type": "goods", "description": "Firearms; ammunition and projectiles; explosives; fireworks"},
+    "14": {"title": "Jewelry", "type": "goods", "description": "Precious metals and their alloys; jewelry, precious and semi-precious stones; horological and chronometric instruments"},
+    "15": {"title": "Musical Instruments", "type": "goods", "description": "Musical instruments; music stands and stands for musical instruments; conductors' batons"},
+    "16": {"title": "Paper Goods and Printed Matter", "type": "goods", "description": "Paper and cardboard; printed matter; bookbinding material; photographs; stationery; office requisites; instructional materials"},
+    "17": {"title": "Rubber Goods", "type": "goods", "description": "Unprocessed rubber, gutta-percha, gum, asbestos, mica; plastics in extruded form; packing and insulating materials; flexible pipes"},
+    "18": {"title": "Leather Goods", "type": "goods", "description": "Leather and imitations of leather; animal skins; luggage and carrying bags; umbrellas and parasols; saddlery"},
+    "19": {"title": "Non-metallic Building Materials", "type": "goods", "description": "Building materials (non-metallic); non-metallic rigid pipes; asphalt, pitch and bitumen; non-metallic transportable buildings; monuments"},
+    "20": {"title": "Furniture and Articles Not Otherwise Classified", "type": "goods", "description": "Furniture, mirrors, picture frames; containers (not of metal) for storage or transport; bone, horn, shell articles"},
+    "21": {"title": "Housewares and Glass", "type": "goods", "description": "Household or kitchen utensils and containers; cookware and tableware; combs and sponges; brushes; glassware, porcelain and earthenware"},
+    "22": {"title": "Cordage and Fibers", "type": "goods", "description": "Ropes and string; nets; tents and tarpaulins; awnings; sails; sacks; padding and stuffing materials; raw fibrous textile materials"},
+    "23": {"title": "Yarns and Threads", "type": "goods", "description": "Yarns and threads for textile use"},
+    "24": {"title": "Fabrics", "type": "goods", "description": "Textiles and substitutes for textiles; household linen; curtains of textile or plastic"},
+    "25": {"title": "Clothing", "type": "goods", "description": "Clothing, footwear, headwear"},
+    "26": {"title": "Fancy Goods", "type": "goods", "description": "Lace, braid and embroidery; buttons, hooks and eyes, pins and needles; artificial flowers; hair decorations; false hair"},
+    "27": {"title": "Floor Coverings", "type": "goods", "description": "Carpets, rugs, mats and matting; linoleum and other materials for covering floors; wall hangings (non-textile)"},
+    "28": {"title": "Toys and Sporting Goods", "type": "goods", "description": "Games, toys and playthings; video game apparatus; gymnastic and sporting articles; decorations for Christmas trees"},
+    "29": {"title": "Meats and Processed Foods", "type": "goods", "description": "Meat, fish, poultry and game; preserved, frozen, dried and cooked fruits and vegetables; jellies, jams; eggs; milk and milk products; edible oils"},
+    "30": {"title": "Staple Foods", "type": "goods", "description": "Coffee, tea, cocoa; rice, pasta and noodles; flour and preparations made from cereals; bread, pastries and confectionery; salt; spices"},
+    "31": {"title": "Natural Agricultural Products", "type": "goods", "description": "Raw and unprocessed agricultural, aquacultural, horticultural and forestry products; fresh fruits and vegetables; live animals; seeds"},
+    "32": {"title": "Light Beverages", "type": "goods", "description": "Beers; non-alcoholic beverages; mineral and aerated waters; fruit beverages and fruit juices; syrups for making beverages"},
+    "33": {"title": "Wines and Spirits", "type": "goods", "description": "Alcoholic beverages (except beers); alcoholic preparations for making beverages"},
+    "34": {"title": "Smokers' Articles", "type": "goods", "description": "Tobacco and tobacco substitutes; cigarettes and cigars; electronic cigarettes and oral vaporizers; smokers' articles; matches"},
+    "35": {"title": "Advertising and Business", "type": "services", "description": "Advertising; business management, organization and administration; office functions; retail and online store services"},
+    "36": {"title": "Insurance and Financial", "type": "services", "description": "Financial, monetary and banking services; insurance services; real estate services"},
+    "37": {"title": "Building Construction and Repair", "type": "services", "description": "Construction services; installation and repair services; mining extraction, oil and gas drilling"},
+    "38": {"title": "Telecommunications", "type": "services", "description": "Telecommunications services; broadcasting; providing internet chatrooms and forums"},
+    "39": {"title": "Transportation and Storage", "type": "services", "description": "Transport; packaging and storage of goods; travel arrangement"},
+    "40": {"title": "Treatment of Materials", "type": "services", "description": "Treatment of materials; recycling of waste and trash; air purification; custom manufacturing; 3D printing services"},
+    "41": {"title": "Education and Entertainment", "type": "services", "description": "Education; providing of training; entertainment; sporting and cultural activities"},
+    "42": {"title": "Computer and Scientific", "type": "services", "description": "Scientific and technological services; industrial research; design and development of computer hardware and software; SaaS; IT services"},
+    "43": {"title": "Hotels and Restaurants", "type": "services", "description": "Services for providing food and drink; temporary accommodation; restaurant, bar and catering services"},
+    "44": {"title": "Medical, Beauty and Agricultural", "type": "services", "description": "Medical services; veterinary services; hygienic and beauty care; agriculture, horticulture and forestry services"},
+    "45": {"title": "Personal and Legal", "type": "services", "description": "Legal services; security services; personal and social services rendered by others to meet the needs of individuals"},
+}
+
+# USPTO Trademark Status Codes (commonly encountered subset).
+# TSDR responses include the status description inline; this reference covers
+# the codes most often seen in search results and portfolio reviews.
+TM_STATUS_CODES = {
+    # New applications / examination
+    "630": {"description": "New application - record initialized, not assigned to examiner", "stage": "pre-examination"},
+    "638": {"description": "New application - assigned to examiner", "stage": "examination"},
+    "640": {"description": "Non-final action - mailed", "stage": "examination"},
+    "644": {"description": "Final refusal - mailed", "stage": "examination"},
+    "650": {"description": "Suspension letter - mailed", "stage": "suspension"},
+    "660": {"description": "Examiner's amendment - mailed", "stage": "examination"},
+    "661": {"description": "Response after non-final action - entered", "stage": "examination"},
+    "681": {"description": "Publication/issue review complete", "stage": "publication"},
+
+    # Publication / allowance
+    "686": {"description": "Published for opposition", "stage": "publication"},
+    "688": {"description": "Notice of allowance - issued", "stage": "allowance"},
+    "730": {"description": "First extension of time to file statement of use - granted", "stage": "allowance"},
+
+    # Registration
+    "700": {"description": "Registered", "stage": "registered"},
+    "701": {"description": "Section 8 declaration - accepted", "stage": "registered"},
+    "702": {"description": "Section 8 & 15 declarations - accepted and acknowledged", "stage": "registered"},
+    "800": {"description": "Registered and renewed", "stage": "registered"},
+
+    # Abandonment
+    "602": {"description": "Abandoned - failure to respond or late response", "stage": "abandoned"},
+    "604": {"description": "Abandoned - express abandonment", "stage": "abandoned"},
+    "606": {"description": "Abandoned - after ex parte appeal", "stage": "abandoned"},
+    "608": {"description": "Abandoned - no statement of use filed", "stage": "abandoned"},
+
+    # Cancellation / expiration
+    "710": {"description": "Cancelled - Section 8 (failure to file declaration of use)", "stage": "cancelled"},
+    "712": {"description": "Cancelled by court order", "stage": "cancelled"},
+    "900": {"description": "Expired - registration not renewed", "stage": "expired"},
+}
+
 # Data Sources Information
 DATA_SOURCES = {
     "ppubs": {
@@ -380,6 +466,92 @@ DATA_SOURCES = {
             "Patent enforcement patterns (UNAVAILABLE - use OCE bulk dataset)",
         ],
     },
+    "tsdr": {
+        "name": "USPTO Trademark Status and Document Retrieval (TSDR)",
+        "base_url": "https://tsdrapi.uspto.gov/ts/cd",
+        "description": (
+            "Official API for live trademark case status, prosecution "
+            "documents, and mark images, keyed by serial or registration "
+            "number. Requires an API key sent as the USPTO-API-KEY header "
+            "(TSDR_API_KEY env var, falls back to USPTO_API_KEY)."
+        ),
+        "coverage": {
+            "status": "Live status for all US trademark applications and registrations",
+            "documents": "Prosecution history document bundles (PDF)",
+            "images": "Mark drawings/images",
+        },
+        "rate_limits": "60 requests/min general; 4 requests/min for PDF/ZIP downloads (per API key)",
+        "auth_required": True,
+        "best_for": [
+            "Authoritative live status of a specific trademark",
+            "Office actions, specimens, and other file-wrapper documents",
+            "Mark images for design marks",
+            "Renewal deadline data (Section 8/9 dates)",
+        ],
+    },
+    "tmsearch": {
+        "name": "USPTO Trademark Search (tmsearch.uspto.gov)",
+        "base_url": "https://tmsearch.uspto.gov",
+        "description": (
+            "Full-text trademark search via the undocumented internal API "
+            "behind the USPTO trademark search web app (the TESS "
+            "replacement). Same risk profile as PPUBS: not an official "
+            "public API and may change without notice. USPTO offers no "
+            "official REST API for full-text trademark search."
+        ),
+        "coverage": {
+            "trademarks": "US federal trademark applications and registrations, searchable by mark text, owner, and class",
+        },
+        "rate_limits": "Undocumented, but throttled for heavy usage",
+        "auth_required": False,
+        "best_for": [
+            "Clearance/knockout searches for a proposed mark",
+            "Finding marks by owner name",
+            "Filtering by Nice international class and live/dead status",
+        ],
+    },
+    "tm_assignments": {
+        "name": "USPTO Trademark Assignment Search",
+        "base_url": "https://api.uspto.gov (legacy fallback: https://assignment-api.uspto.gov)",
+        "description": (
+            "Recorded trademark assignment (ownership transfer) records, "
+            "1955-present. The legacy assignment-api.uspto.gov service was "
+            "migrated to the Open Data Portal around April 2026; the client "
+            "tries ODP first and falls back to the legacy XML API."
+        ),
+        "coverage": {
+            "assignments": "Recorded trademark assignments from 1955 to present",
+        },
+        "rate_limits": "Standard ODP rate limits on the ODP backend",
+        "auth_required": True,
+        "best_for": [
+            "Tracing trademark ownership history",
+            "Finding marks assigned to or from a company",
+            "Due diligence on trademark transfers",
+        ],
+    },
+    "ttab": {
+        "name": "Trademark Trial and Appeal Board (TTAB)",
+        "base_url": "N/A",
+        "description": (
+            "NOT AVAILABLE AS API. TTAB proceedings (oppositions, "
+            "cancellations, ex parte appeals) have no public REST API. Case "
+            "status and documents are available via the TTABVUE web "
+            "interface, and daily TTAB XML data is published as bulk "
+            "datasets on the Open Data Portal (find products via "
+            "odp_search_datasets, e.g. the Trademark Daily XML File TTAB "
+            "product)."
+        ),
+        "coverage": {
+            "proceedings": "Bulk XML only - use odp_search_datasets",
+        },
+        "rate_limits": "N/A",
+        "auth_required": False,
+        "best_for": [
+            "Opposition/cancellation research (bulk XML via odp_search_datasets)",
+            "TTAB decisions (bulk XML via odp_search_datasets)",
+        ],
+    },
 }
 
 # Search Query Syntax Guide
@@ -411,6 +583,9 @@ PPUBS uses a field-based search syntax:
 ---
 
 ## PatentsView
+
+NOTE: The PatentsView API was shut down March 20, 2026. This syntax is
+retained for reference only; use PPUBS or ODP search instead.
 
 PatentsView uses JSON query syntax:
 
@@ -452,6 +627,25 @@ PatentsView uses JSON query syntax:
 
 ### Example:
 `q=machine learning&appFilingDate=2020-01-01,2023-12-31`
+
+---
+
+## Trademark Search (tm_search_trademarks)
+
+Search US federal trademarks by one or more filters:
+
+- `mark_text` - Word mark text (e.g., "ACME")
+- `owner_name` - Owner/applicant name (e.g., "Acme Corporation")
+- `international_class` - Nice class number 1-45 (e.g., "9" for software, "25" for clothing)
+- `status_filter` - "live" (active marks only), "dead" (abandoned/cancelled/expired), or omit for both
+- `query` - Raw query string for advanced searches
+
+### Clearance search tips:
+1. Start broad: search the exact proposed mark with status_filter="live"
+2. Search phonetic and spelling variants separately (e.g., "KWIK" for "QUICK")
+3. Narrow by international_class once you know the relevant classes (use get_trademark_class_info)
+4. Check authoritative status of any close hits with tsdr_get_trademark_status
+5. Federal search only - common-law and state marks are not covered
 
 ---
 
@@ -514,6 +708,40 @@ def get_status_code_info(code: str) -> dict:
 def get_all_status_codes() -> dict:
     """Get all USPTO status codes."""
     return STATUS_CODES
+
+
+def get_trademark_class_info(class_number: str) -> dict:
+    """Get information about a Nice/international trademark class."""
+    cleaned = str(class_number).strip().lstrip("0") or "0"
+    if cleaned in NICE_CLASSES:
+        info = NICE_CLASSES[cleaned].copy()
+        info["class"] = cleaned
+        return info
+    return {"error": f"Unknown trademark class: {class_number}. Valid classes are 1-45 (goods 1-34, services 35-45)."}
+
+
+def get_all_trademark_classes() -> dict:
+    """Get all Nice/international trademark classes."""
+    return NICE_CLASSES
+
+
+def get_trademark_status_code_info(code: str) -> dict:
+    """Get information about a USPTO trademark status code."""
+    code = str(code).strip()
+    if code in TM_STATUS_CODES:
+        info = TM_STATUS_CODES[code].copy()
+        info["code"] = code
+        return info
+    return {
+        "error": f"Unknown trademark status code: {code}. This reference covers "
+                 "commonly encountered codes only; TSDR status responses include "
+                 "the full status description inline (tsdr_get_trademark_status)."
+    }
+
+
+def get_all_trademark_status_codes() -> dict:
+    """Get all known USPTO trademark status codes."""
+    return TM_STATUS_CODES
 
 
 def get_data_source_info(source: str) -> dict:

--- a/src/patent_mcp_server/uspto/tm_assignment_client.py
+++ b/src/patent_mcp_server/uspto/tm_assignment_client.py
@@ -1,27 +1,25 @@
 """
-USPTO Trademark Assignment Search Module
+USPTO Trademark Assignment Search Module (assignmentcenter.uspto.gov)
 
 Searches recorded trademark assignment (ownership transfer) records,
 covering the USPTO assignment database (1955-present).
 
-BACKEND STATUS (2026-06-10): The legacy Trademark Assignment Search API at
-assignment-api.uspto.gov was migrated to the Open Data Portal around April
-2026, but the exact ODP endpoint could not be verified from this environment
-(no network access to uspto.gov hosts). This client therefore probes at
-runtime:
-  1. ODP first: GET {API_BASE_URL}/api/v1/trademark/assignment/search
-     (X-API-KEY auth, JSON responses)
-  2. On 404/501, falls back to the legacy XML API:
-     GET {TM_ASSIGNMENT_BASE_URL}/trademark/basicSearch (no auth, XML)
-The working backend is cached per client instance. Once the live location is
-confirmed, prune the dead path and update this docstring.
+BACKEND (verified live 2026-06-10): the USPTO Assignment Center public API.
+The legacy assignment-api.uspto.gov XML API was decommissioned with the
+Developer Hub on June 5, 2026, and no ODP endpoint exists for trademark
+assignments; Assignment Center is the live replacement.
+
+  POST {TM_ASSIGNMENT_BASE_URL}/ipas/search/api/v2/public/trademark/exportTradeMarkData
+  Body: {"searchCriteria": [{"property": "<value>", "searchBy": "<field>"}, ...]}
+  Pagination criteria: startRow/endRow (1-based) and rowsNeeded (max 1000).
+  Response: [{"searchCriteria": [...], "data": [<records>]}]
+
+No API key is required.
 """
 
-import xml.etree.ElementTree as ET
 from typing import Any, Optional, Dict, List, Union
 import httpx
 import logging
-import urllib.parse
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -37,14 +35,23 @@ from patent_mcp_server.constants import TrademarkDefaults
 # Set up logging
 logger = logging.getLogger('tm_assignment_client')
 
-# ODP candidate path — confirmed at implementation time only as the documented
-# migration target family; verify against https://data.uspto.gov swagger.
-ODP_SEARCH_PATH = "/api/v1/trademark/assignment/search"
-LEGACY_SEARCH_PATH = "/trademark/basicSearch"
+SEARCH_PATH = "/ipas/search/api/v2/public/trademark/exportTradeMarkData"
+
+# Maximum rows the Assignment Center API returns per request
+MAX_ROWS_PER_REQUEST = 1000
+
+# Map of our filter names to Assignment Center searchBy values
+SEARCH_BY_FIELDS = {
+    "serial_number": "serialNumber",
+    "registration_number": "registrationNumber",
+    "assignee_name": "assigneeName",
+    "assignor_name": "assignorName",
+    "reel_frame": "reelFrame",
+}
 
 
 class TmAssignmentClient:
-    """Client for trademark assignment search (ODP with legacy fallback).
+    """Client for trademark assignment search via USPTO Assignment Center.
 
     Supports context manager protocol for proper resource cleanup.
     """
@@ -52,11 +59,9 @@ class TmAssignmentClient:
     def __init__(self):
         self.headers = {
             "User-Agent": config.USER_AGENT,
-            "X-API-KEY": config.USPTO_API_KEY if config.USPTO_API_KEY else ""
+            "Accept": "application/json",
+            "Content-Type": "application/json",
         }
-
-        # Which backend answered last: None (unprobed), "odp", or "legacy"
-        self._backend: Optional[str] = None
 
         # Create a custom transport that logs all requests and responses
         transport = httpx.AsyncHTTPTransport()
@@ -78,6 +83,62 @@ class TmAssignmentClient:
         """Async context manager exit with cleanup."""
         await self.close()
 
+    @staticmethod
+    def build_search_criteria(
+        filters: Dict[str, str],
+        offset: int = 0,
+        limit: int = TrademarkDefaults.SEARCH_LIMIT,
+    ) -> List[Dict[str, str]]:
+        """Build the Assignment Center searchCriteria list.
+
+        Pure function; fully unit-testable offline. Every entry is a
+        {"property": <value>, "searchBy": <field>} pair; pagination rides
+        along as startRow/endRow/rowsNeeded criteria.
+
+        Args:
+            filters: Mapping of our filter names (see SEARCH_BY_FIELDS) to values
+            offset: 0-based pagination offset (converted to 1-based rows)
+            limit: Maximum results (capped at MAX_ROWS_PER_REQUEST)
+
+        Returns:
+            List of searchCriteria dictionaries
+        """
+        criteria = [
+            {"property": value, "searchBy": SEARCH_BY_FIELDS[name]}
+            for name, value in filters.items()
+        ]
+
+        limit = min(limit, MAX_ROWS_PER_REQUEST)
+        if offset > 0:
+            start_row = offset + 1  # API rows are 1-based
+            criteria.append({"property": str(start_row), "searchBy": "startRow"})
+            criteria.append({"property": str(start_row + limit - 1), "searchBy": "endRow"})
+        criteria.append({"property": str(limit), "searchBy": "rowsNeeded"})
+
+        return criteria
+
+    @staticmethod
+    def parse_search_response(raw: Any) -> Dict[str, Any]:
+        """Extract assignment records from the Assignment Center envelope.
+
+        The API returns a list with one element: {"searchCriteria": [...],
+        "data": [<records>]}. No overall hit count is reported, so total
+        reflects the number of returned records.
+
+        Args:
+            raw: Parsed JSON response
+
+        Returns:
+            {"results": [...], "total": N}
+        """
+        if isinstance(raw, list) and raw and isinstance(raw[0], dict):
+            records = raw[0].get("data") or []
+            return {"results": records, "total": len(records)}
+        if isinstance(raw, dict):
+            records = raw.get("data") or []
+            return {"results": records, "total": len(records)}
+        return {"results": [], "total": 0}
+
     @retry(
         stop=stop_after_attempt(config.MAX_RETRIES),
         wait=wait_exponential(
@@ -88,10 +149,10 @@ class TmAssignmentClient:
         retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
         reraise=True
     )
-    async def _get(self, url: str) -> Union[httpx.Response, Dict[str, Any]]:
-        """Perform a GET with retry; returns the response or an error dict."""
+    async def _post(self, url: str, body: Dict[str, Any]) -> Union[httpx.Response, Dict[str, Any]]:
+        """Perform a POST with retry; returns the response or an error dict."""
         try:
-            return await self.client.get(url, timeout=config.REQUEST_TIMEOUT)
+            return await self.client.post(url, json=body, timeout=config.REQUEST_TIMEOUT)
         except (httpx.TimeoutException, httpx.NetworkError) as e:
             logger.warning(f"Network error (will retry): {str(e)}")
             raise  # Let tenacity handle the retry
@@ -99,203 +160,58 @@ class TmAssignmentClient:
             logger.error(f"Request error: {str(e)}")
             return ApiError.from_exception(e, f"Request to {url} failed")
 
-    @staticmethod
-    def _build_filters(
-        serial_number: Optional[str],
-        registration_number: Optional[str],
-        assignee_name: Optional[str],
-        assignor_name: Optional[str],
-    ) -> Dict[str, str]:
-        """Collect the non-empty filters into a dict; empty dict means none."""
-        filters = {
-            "serial_number": serial_number,
-            "registration_number": registration_number,
-            "assignee_name": assignee_name,
-            "assignor_name": assignor_name,
-        }
-        return {k: v for k, v in filters.items() if v}
-
-    def _parse_legacy_xml(self, xml_text: str) -> Dict[str, Any]:
-        """Parse the legacy assignment-api XML response.
-
-        The legacy API returns Solr-style XML:
-        <response><result numFound="N"><doc>...fields...</doc></result></response>
-        where each <doc> contains typed children (<str>, <arr>, <int>, <date>)
-        keyed by a "name" attribute.
-
-        Args:
-            xml_text: Raw XML response body
-
-        Returns:
-            {"results": [...], "total": N} or error dictionary
-        """
-        try:
-            root = ET.fromstring(xml_text)
-        except ET.ParseError as e:
-            return ApiError.from_exception(e, "Failed to parse legacy assignment XML")
-
-        result_el = root.find(".//result")
-        if result_el is None:
-            return {"results": [], "total": 0}
-
-        try:
-            total = int(result_el.get("numFound", "0"))
-        except ValueError:
-            total = 0
-
-        results: List[Dict[str, Any]] = []
-        for doc in result_el.findall("doc"):
-            record: Dict[str, Any] = {}
-            for child in doc:
-                name = child.get("name")
-                if not name:
-                    continue
-                if child.tag == "arr":
-                    record[name] = [el.text for el in child]
-                else:
-                    record[name] = child.text
-            results.append(record)
-
-        return {"results": results, "total": total}
-
     async def search_assignments(
         self,
         serial_number: Optional[str] = None,
         registration_number: Optional[str] = None,
         assignee_name: Optional[str] = None,
         assignor_name: Optional[str] = None,
+        reel_frame: Optional[str] = None,
         offset: int = 0,
         limit: int = TrademarkDefaults.SEARCH_LIMIT,
     ) -> Dict[str, Any]:
         """Search trademark assignment records.
 
-        At least one filter is required. Tries ODP first, then falls back to
-        the legacy XML API; the working backend is cached on the instance.
+        At least one filter is required; multiple filters combine (AND).
 
         Args:
             serial_number: Trademark application serial number
             registration_number: Trademark registration number
             assignee_name: Assignee (new owner) name
             assignor_name: Assignor (previous owner) name
+            reel_frame: Recordation reel/frame identifier (e.g. "9006/0093")
             offset: Pagination offset
             limit: Maximum results
 
         Returns:
-            {"results": [...], "total": N, "backend": "odp"|"legacy"} or error
+            {"results": [...], "total": N, "backend": "assignment-center"} or error
         """
-        filters = self._build_filters(
-            serial_number, registration_number, assignee_name, assignor_name
-        )
+        filters = {
+            name: value
+            for name, value in {
+                "serial_number": serial_number,
+                "registration_number": registration_number,
+                "assignee_name": assignee_name,
+                "assignor_name": assignor_name,
+                "reel_frame": reel_frame,
+            }.items()
+            if value
+        }
         if not filters:
             return ApiError.create(
                 message=(
                     "At least one filter is required: serial_number, "
-                    "registration_number, assignee_name, or assignor_name"
+                    "registration_number, assignee_name, assignor_name, "
+                    "or reel_frame"
                 ),
                 status_code=400,
                 error_code="MISSING_FILTER"
             )
 
-        if self._backend != "legacy":
-            result = await self._search_odp(filters, offset, limit)
-            # 404/501 means the ODP endpoint isn't there — try legacy.
-            if not (
-                result.get("error", False) is True
-                and result.get("status_code") in (404, 501)
-            ):
-                self._backend = "odp"
-                result["backend"] = "odp"
-                return result
-            logger.info("ODP trademark assignment endpoint unavailable; falling back to legacy API")
+        criteria = self.build_search_criteria(filters, offset=offset, limit=limit)
+        url = f"{config.TM_ASSIGNMENT_BASE_URL}{SEARCH_PATH}"
 
-        result = await self._search_legacy(filters, offset, limit)
-        if result.get("error", False) is not True:
-            self._backend = "legacy"
-            result["backend"] = "legacy"
-        return result
-
-    async def _search_odp(
-        self,
-        filters: Dict[str, str],
-        offset: int,
-        limit: int,
-    ) -> Dict[str, Any]:
-        """Query the ODP trademark assignment endpoint (JSON)."""
-        # ODP search APIs use Lucene-style q= filtering
-        clauses = []
-        if "serial_number" in filters:
-            clauses.append(f'applicationNumberText:{filters["serial_number"]}')
-        if "registration_number" in filters:
-            clauses.append(f'registrationNumber:{filters["registration_number"]}')
-        if "assignee_name" in filters:
-            clauses.append(f'assigneeName:"{filters["assignee_name"]}"')
-        if "assignor_name" in filters:
-            clauses.append(f'assignorName:"{filters["assignor_name"]}"')
-        q = " AND ".join(clauses)
-
-        params = urllib.parse.urlencode({"q": q, "offset": offset, "limit": limit})
-        url = f"{config.API_BASE_URL}{ODP_SEARCH_PATH}?{params}"
-
-        response = await self._get(url)
-        if isinstance(response, dict):
-            return response  # Already an error dict
-
-        if response.status_code != 200:
-            try:
-                error_json = response.json()
-                return ApiError.from_http_error(
-                    status_code=response.status_code,
-                    response_text=response.text,
-                    response_json=error_json
-                )
-            except Exception:
-                return ApiError.from_http_error(
-                    status_code=response.status_code,
-                    response_text=response.text
-                )
-
-        try:
-            raw = response.json()
-        except Exception as e:
-            return ApiError.from_exception(e, "ODP returned non-JSON response")
-
-        # Normalize possible bag shapes into {"results", "total"}
-        if isinstance(raw, dict):
-            results = (
-                raw.get("results")
-                or raw.get("assignmentBag")
-                or raw.get("trademarkAssignmentDataBag")
-                or []
-            )
-            total = raw.get("count", raw.get("total", len(results)))
-            return {"results": results, "total": total}
-        return {"results": raw, "total": len(raw) if isinstance(raw, list) else 1}
-
-    async def _search_legacy(
-        self,
-        filters: Dict[str, str],
-        offset: int,
-        limit: int,
-    ) -> Dict[str, Any]:
-        """Query the legacy assignment-api.uspto.gov XML endpoint."""
-        # Legacy API takes a single query value plus a filter field name
-        legacy_fields = {
-            "serial_number": "ApplicationNumber",
-            "registration_number": "RegistrationNumber",
-            "assignee_name": "AssigneeName",
-            "assignor_name": "AssignorName",
-        }
-        # Use the first provided filter as the primary query
-        key, value = next(iter(filters.items()))
-        params = urllib.parse.urlencode({
-            "query": value,
-            "filter_field": legacy_fields[key],
-            "rows": limit,
-            "start": offset,
-        })
-        url = f"{config.TM_ASSIGNMENT_BASE_URL}{LEGACY_SEARCH_PATH}?{params}"
-
-        response = await self._get(url)
+        response = await self._post(url, {"searchCriteria": criteria})
         if isinstance(response, dict):
             return response  # Already an error dict
 
@@ -305,7 +221,16 @@ class TmAssignmentClient:
                 response_text=response.text
             )
 
-        return self._parse_legacy_xml(response.text)
+        try:
+            raw = response.json()
+        except Exception as e:
+            return ApiError.from_exception(
+                e, "Assignment Center returned non-JSON response"
+            )
+
+        result = self.parse_search_response(raw)
+        result["backend"] = "assignment-center"
+        return result
 
     async def close(self):
         """Close the client connections and clean up resources."""

--- a/src/patent_mcp_server/uspto/tm_assignment_client.py
+++ b/src/patent_mcp_server/uspto/tm_assignment_client.py
@@ -1,0 +1,313 @@
+"""
+USPTO Trademark Assignment Search Module
+
+Searches recorded trademark assignment (ownership transfer) records,
+covering the USPTO assignment database (1955-present).
+
+BACKEND STATUS (2026-06-10): The legacy Trademark Assignment Search API at
+assignment-api.uspto.gov was migrated to the Open Data Portal around April
+2026, but the exact ODP endpoint could not be verified from this environment
+(no network access to uspto.gov hosts). This client therefore probes at
+runtime:
+  1. ODP first: GET {API_BASE_URL}/api/v1/trademark/assignment/search
+     (X-API-KEY auth, JSON responses)
+  2. On 404/501, falls back to the legacy XML API:
+     GET {TM_ASSIGNMENT_BASE_URL}/trademark/basicSearch (no auth, XML)
+The working backend is cached per client instance. Once the live location is
+confirmed, prune the dead path and update this docstring.
+"""
+
+import xml.etree.ElementTree as ET
+from typing import Any, Optional, Dict, List, Union
+import httpx
+import logging
+import urllib.parse
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+)
+
+from patent_mcp_server.util.logging import LoggingTransport
+from patent_mcp_server.util.errors import ApiError
+from patent_mcp_server.config import config
+from patent_mcp_server.constants import TrademarkDefaults
+
+# Set up logging
+logger = logging.getLogger('tm_assignment_client')
+
+# ODP candidate path — confirmed at implementation time only as the documented
+# migration target family; verify against https://data.uspto.gov swagger.
+ODP_SEARCH_PATH = "/api/v1/trademark/assignment/search"
+LEGACY_SEARCH_PATH = "/trademark/basicSearch"
+
+
+class TmAssignmentClient:
+    """Client for trademark assignment search (ODP with legacy fallback).
+
+    Supports context manager protocol for proper resource cleanup.
+    """
+
+    def __init__(self):
+        self.headers = {
+            "User-Agent": config.USER_AGENT,
+            "X-API-KEY": config.USPTO_API_KEY if config.USPTO_API_KEY else ""
+        }
+
+        # Which backend answered last: None (unprobed), "odp", or "legacy"
+        self._backend: Optional[str] = None
+
+        # Create a custom transport that logs all requests and responses
+        transport = httpx.AsyncHTTPTransport()
+        logging_transport = LoggingTransport(transport)
+
+        self.client = httpx.AsyncClient(
+            headers=self.headers,
+            http2=True,
+            follow_redirects=True,
+            transport=logging_transport,
+            timeout=config.REQUEST_TIMEOUT,
+        )
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit with cleanup."""
+        await self.close()
+
+    @retry(
+        stop=stop_after_attempt(config.MAX_RETRIES),
+        wait=wait_exponential(
+            multiplier=config.RETRY_DELAY,
+            min=config.RETRY_MIN_WAIT,
+            max=config.RETRY_MAX_WAIT
+        ),
+        retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+        reraise=True
+    )
+    async def _get(self, url: str) -> Union[httpx.Response, Dict[str, Any]]:
+        """Perform a GET with retry; returns the response or an error dict."""
+        try:
+            return await self.client.get(url, timeout=config.REQUEST_TIMEOUT)
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            logger.warning(f"Network error (will retry): {str(e)}")
+            raise  # Let tenacity handle the retry
+        except Exception as e:
+            logger.error(f"Request error: {str(e)}")
+            return ApiError.from_exception(e, f"Request to {url} failed")
+
+    @staticmethod
+    def _build_filters(
+        serial_number: Optional[str],
+        registration_number: Optional[str],
+        assignee_name: Optional[str],
+        assignor_name: Optional[str],
+    ) -> Dict[str, str]:
+        """Collect the non-empty filters into a dict; empty dict means none."""
+        filters = {
+            "serial_number": serial_number,
+            "registration_number": registration_number,
+            "assignee_name": assignee_name,
+            "assignor_name": assignor_name,
+        }
+        return {k: v for k, v in filters.items() if v}
+
+    def _parse_legacy_xml(self, xml_text: str) -> Dict[str, Any]:
+        """Parse the legacy assignment-api XML response.
+
+        The legacy API returns Solr-style XML:
+        <response><result numFound="N"><doc>...fields...</doc></result></response>
+        where each <doc> contains typed children (<str>, <arr>, <int>, <date>)
+        keyed by a "name" attribute.
+
+        Args:
+            xml_text: Raw XML response body
+
+        Returns:
+            {"results": [...], "total": N} or error dictionary
+        """
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError as e:
+            return ApiError.from_exception(e, "Failed to parse legacy assignment XML")
+
+        result_el = root.find(".//result")
+        if result_el is None:
+            return {"results": [], "total": 0}
+
+        try:
+            total = int(result_el.get("numFound", "0"))
+        except ValueError:
+            total = 0
+
+        results: List[Dict[str, Any]] = []
+        for doc in result_el.findall("doc"):
+            record: Dict[str, Any] = {}
+            for child in doc:
+                name = child.get("name")
+                if not name:
+                    continue
+                if child.tag == "arr":
+                    record[name] = [el.text for el in child]
+                else:
+                    record[name] = child.text
+            results.append(record)
+
+        return {"results": results, "total": total}
+
+    async def search_assignments(
+        self,
+        serial_number: Optional[str] = None,
+        registration_number: Optional[str] = None,
+        assignee_name: Optional[str] = None,
+        assignor_name: Optional[str] = None,
+        offset: int = 0,
+        limit: int = TrademarkDefaults.SEARCH_LIMIT,
+    ) -> Dict[str, Any]:
+        """Search trademark assignment records.
+
+        At least one filter is required. Tries ODP first, then falls back to
+        the legacy XML API; the working backend is cached on the instance.
+
+        Args:
+            serial_number: Trademark application serial number
+            registration_number: Trademark registration number
+            assignee_name: Assignee (new owner) name
+            assignor_name: Assignor (previous owner) name
+            offset: Pagination offset
+            limit: Maximum results
+
+        Returns:
+            {"results": [...], "total": N, "backend": "odp"|"legacy"} or error
+        """
+        filters = self._build_filters(
+            serial_number, registration_number, assignee_name, assignor_name
+        )
+        if not filters:
+            return ApiError.create(
+                message=(
+                    "At least one filter is required: serial_number, "
+                    "registration_number, assignee_name, or assignor_name"
+                ),
+                status_code=400,
+                error_code="MISSING_FILTER"
+            )
+
+        if self._backend != "legacy":
+            result = await self._search_odp(filters, offset, limit)
+            # 404/501 means the ODP endpoint isn't there — try legacy.
+            if not (
+                result.get("error", False) is True
+                and result.get("status_code") in (404, 501)
+            ):
+                self._backend = "odp"
+                result["backend"] = "odp"
+                return result
+            logger.info("ODP trademark assignment endpoint unavailable; falling back to legacy API")
+
+        result = await self._search_legacy(filters, offset, limit)
+        if result.get("error", False) is not True:
+            self._backend = "legacy"
+            result["backend"] = "legacy"
+        return result
+
+    async def _search_odp(
+        self,
+        filters: Dict[str, str],
+        offset: int,
+        limit: int,
+    ) -> Dict[str, Any]:
+        """Query the ODP trademark assignment endpoint (JSON)."""
+        # ODP search APIs use Lucene-style q= filtering
+        clauses = []
+        if "serial_number" in filters:
+            clauses.append(f'applicationNumberText:{filters["serial_number"]}')
+        if "registration_number" in filters:
+            clauses.append(f'registrationNumber:{filters["registration_number"]}')
+        if "assignee_name" in filters:
+            clauses.append(f'assigneeName:"{filters["assignee_name"]}"')
+        if "assignor_name" in filters:
+            clauses.append(f'assignorName:"{filters["assignor_name"]}"')
+        q = " AND ".join(clauses)
+
+        params = urllib.parse.urlencode({"q": q, "offset": offset, "limit": limit})
+        url = f"{config.API_BASE_URL}{ODP_SEARCH_PATH}?{params}"
+
+        response = await self._get(url)
+        if isinstance(response, dict):
+            return response  # Already an error dict
+
+        if response.status_code != 200:
+            try:
+                error_json = response.json()
+                return ApiError.from_http_error(
+                    status_code=response.status_code,
+                    response_text=response.text,
+                    response_json=error_json
+                )
+            except Exception:
+                return ApiError.from_http_error(
+                    status_code=response.status_code,
+                    response_text=response.text
+                )
+
+        try:
+            raw = response.json()
+        except Exception as e:
+            return ApiError.from_exception(e, "ODP returned non-JSON response")
+
+        # Normalize possible bag shapes into {"results", "total"}
+        if isinstance(raw, dict):
+            results = (
+                raw.get("results")
+                or raw.get("assignmentBag")
+                or raw.get("trademarkAssignmentDataBag")
+                or []
+            )
+            total = raw.get("count", raw.get("total", len(results)))
+            return {"results": results, "total": total}
+        return {"results": raw, "total": len(raw) if isinstance(raw, list) else 1}
+
+    async def _search_legacy(
+        self,
+        filters: Dict[str, str],
+        offset: int,
+        limit: int,
+    ) -> Dict[str, Any]:
+        """Query the legacy assignment-api.uspto.gov XML endpoint."""
+        # Legacy API takes a single query value plus a filter field name
+        legacy_fields = {
+            "serial_number": "ApplicationNumber",
+            "registration_number": "RegistrationNumber",
+            "assignee_name": "AssigneeName",
+            "assignor_name": "AssignorName",
+        }
+        # Use the first provided filter as the primary query
+        key, value = next(iter(filters.items()))
+        params = urllib.parse.urlencode({
+            "query": value,
+            "filter_field": legacy_fields[key],
+            "rows": limit,
+            "start": offset,
+        })
+        url = f"{config.TM_ASSIGNMENT_BASE_URL}{LEGACY_SEARCH_PATH}?{params}"
+
+        response = await self._get(url)
+        if isinstance(response, dict):
+            return response  # Already an error dict
+
+        if response.status_code != 200:
+            return ApiError.from_http_error(
+                status_code=response.status_code,
+                response_text=response.text
+            )
+
+        return self._parse_legacy_xml(response.text)
+
+    async def close(self):
+        """Close the client connections and clean up resources."""
+        logger.info("Closing trademark assignment client connections")
+        await self.client.aclose()

--- a/src/patent_mcp_server/uspto/tmsearch_client.py
+++ b/src/patent_mcp_server/uspto/tmsearch_client.py
@@ -1,0 +1,292 @@
+"""
+USPTO Trademark Search Module (tmsearch.uspto.gov)
+
+This module provides full-text trademark search via the *undocumented internal*
+JSON API behind the USPTO trademark search web application (the TESS
+replacement at https://tmsearch.uspto.gov). This is the same risk profile as
+the PPUBS internal API used by ppubs_uspto_gov.py: it is not an official
+public API and may change or break without notice.
+
+CONTRACT STATUS (2026-06-10): BEST-EFFORT — NOT verified against the live
+service (this environment has no network access to uspto.gov hosts). The
+request body is an Elasticsearch-style query POSTed to SEARCH_PATH, based on
+public observations of the web app's network calls. Before relying on this
+client, confirm the request/response shape via browser dev tools on
+tmsearch.uspto.gov and adjust ONLY these three seams:
+  - SEARCH_PATH (module constant below)
+  - constants.TmSearchFields (index field names)
+  - TmSearchClient.build_search_body / parse_search_response
+
+No API key is required.
+"""
+
+from typing import Any, Optional, Dict
+import httpx
+import logging
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+)
+
+from patent_mcp_server.util.logging import LoggingTransport
+from patent_mcp_server.util.errors import ApiError
+from patent_mcp_server.config import config
+from patent_mcp_server.constants import TmSearchFields, TrademarkDefaults
+
+# Set up logging
+logger = logging.getLogger('tmsearch_client')
+
+# POST target for the internal search API, relative to config.TMSEARCH_BASE_URL.
+# Single place to fix if the web app's endpoint moves.
+SEARCH_PATH = "/api-v1-0-0/tmsearch"
+
+
+class TmSearchClient:
+    """Client for the undocumented trademark search API at tmsearch.uspto.gov.
+
+    Sends browser-like headers (the internal API serves the web app). No
+    session management is needed as of the last observation; if the service
+    starts requiring a token, copy the get_session() pattern from PpubsClient.
+
+    Supports context manager protocol for proper resource cleanup.
+    """
+
+    def __init__(self):
+        self.headers = {
+            "User-Agent": config.USER_AGENT,
+            "X-Requested-With": "XMLHttpRequest",
+            "Origin": config.TMSEARCH_BASE_URL,
+            "Referer": f"{config.TMSEARCH_BASE_URL}/search/search-information",
+            "Content-Type": "application/json",
+        }
+
+        # Create a custom transport that logs all requests and responses
+        transport = httpx.AsyncHTTPTransport()
+        logging_transport = LoggingTransport(transport)
+
+        self.client = httpx.AsyncClient(
+            headers=self.headers,
+            http2=True,
+            follow_redirects=True,
+            transport=logging_transport,
+            timeout=config.REQUEST_TIMEOUT,
+        )
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit with cleanup."""
+        await self.close()
+
+    @staticmethod
+    def build_search_body(
+        query: Optional[str] = None,
+        mark_text: Optional[str] = None,
+        owner_name: Optional[str] = None,
+        serial_number: Optional[str] = None,
+        registration_number: Optional[str] = None,
+        international_class: Optional[str] = None,
+        status_filter: Optional[str] = None,
+        offset: int = 0,
+        limit: int = TrademarkDefaults.SEARCH_LIMIT,
+    ) -> Dict[str, Any]:
+        """Construct the Elasticsearch-style request body.
+
+        BEST-EFFORT SHAPE — confirm against live tmsearch.uspto.gov network
+        calls before release (see module docstring). Pure function; fully
+        unit-testable offline.
+
+        Args:
+            query: Raw query string (Elasticsearch query_string syntax)
+            mark_text: Word mark text to match
+            owner_name: Owner name to match
+            serial_number: Exact serial number
+            registration_number: Exact registration number
+            international_class: Nice international class number (e.g. "9")
+            status_filter: "live", "dead", or None for both
+            offset: Pagination offset
+            limit: Maximum results
+
+        Returns:
+            Request body dictionary
+        """
+        must = []
+        filters = []
+
+        if query:
+            must.append({
+                "query_string": {
+                    "query": query,
+                    "default_field": TmSearchFields.WORDMARK,
+                }
+            })
+        if mark_text:
+            must.append({"match": {TmSearchFields.WORDMARK: mark_text}})
+        if owner_name:
+            must.append({"match": {TmSearchFields.OWNER: owner_name}})
+        if serial_number:
+            must.append({"term": {TmSearchFields.SERIAL_NUMBER: serial_number}})
+        if registration_number:
+            must.append({"term": {TmSearchFields.REGISTRATION_NUMBER: registration_number}})
+
+        if international_class:
+            filters.append({"term": {TmSearchFields.INTERNATIONAL_CLASS: international_class}})
+        if status_filter:
+            status = status_filter.strip().lower()
+            if status == "live":
+                filters.append({"term": {TmSearchFields.ALIVE: True}})
+            elif status == "dead":
+                filters.append({"term": {TmSearchFields.ALIVE: False}})
+
+        bool_query: Dict[str, Any] = {}
+        if must:
+            bool_query["must"] = must
+        if filters:
+            bool_query["filter"] = filters
+        if not bool_query:
+            bool_query["must"] = [{"match_all": {}}]
+
+        return {
+            "query": {"bool": bool_query},
+            "from": offset,
+            "size": min(limit, TrademarkDefaults.SEARCH_LIMIT_MAX),
+            "track_total_hits": True,
+        }
+
+    @staticmethod
+    def parse_search_response(raw: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract results and total from the Elasticsearch-style envelope.
+
+        Handles both ES7-style {"hits": {"total": {"value": N}, "hits": [...]}}
+        and older {"hits": {"total": N, "hits": [...]}} envelopes.
+
+        Args:
+            raw: Raw JSON response from the search endpoint
+
+        Returns:
+            {"results": [...], "total": N}
+        """
+        hits_obj = raw.get("hits")
+        if not isinstance(hits_obj, dict):
+            return {"results": [], "total": 0}
+
+        hits = hits_obj.get("hits", [])
+        results = []
+        for hit in hits:
+            if isinstance(hit, dict):
+                results.append(hit.get("_source", hit))
+
+        total = hits_obj.get("total", len(results))
+        if isinstance(total, dict):
+            total = total.get("value", len(results))
+
+        return {"results": results, "total": total}
+
+    @retry(
+        stop=stop_after_attempt(config.MAX_RETRIES),
+        wait=wait_exponential(
+            multiplier=config.RETRY_DELAY,
+            min=config.RETRY_MIN_WAIT,
+            max=config.RETRY_MAX_WAIT
+        ),
+        retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+        reraise=True
+    )
+    async def make_request(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        """POST a search body to the internal search endpoint.
+
+        Args:
+            body: Request body from build_search_body
+
+        Returns:
+            Raw JSON response or error dictionary
+        """
+        url = f"{config.TMSEARCH_BASE_URL}{SEARCH_PATH}"
+        logger.info(f"Making tmsearch request to {url}")
+
+        try:
+            response = await self.client.post(
+                url,
+                json=body,
+                timeout=config.REQUEST_TIMEOUT
+            )
+            response.raise_for_status()
+            return response.json()
+
+        except httpx.HTTPStatusError as e:
+            status_code = e.response.status_code
+            logger.error(f"HTTP error: {status_code} - {e.response.text}")
+            error = ApiError.from_http_error(
+                status_code=status_code,
+                response_text=e.response.text
+            )
+            if status_code in (400, 404):
+                error["hint"] = (
+                    "tmsearch.uspto.gov is an undocumented internal API; this "
+                    "failure may mean the endpoint or query shape has changed. "
+                    "See the contract notes in tmsearch_client.py."
+                )
+            return error
+
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            logger.warning(f"Network error (will retry): {str(e)}")
+            raise  # Let tenacity handle the retry
+
+        except Exception as e:
+            logger.error(f"Unexpected error: {str(e)}")
+            return ApiError.from_exception(e, f"Request to {url} failed")
+
+    async def search(
+        self,
+        query: Optional[str] = None,
+        mark_text: Optional[str] = None,
+        owner_name: Optional[str] = None,
+        serial_number: Optional[str] = None,
+        registration_number: Optional[str] = None,
+        international_class: Optional[str] = None,
+        status_filter: Optional[str] = None,
+        offset: int = 0,
+        limit: int = TrademarkDefaults.SEARCH_LIMIT,
+    ) -> Dict[str, Any]:
+        """Search trademarks and return a parsed {"results", "total"} dict.
+
+        Returns:
+            {"results": [...], "total": N} or error dictionary
+        """
+        body = self.build_search_body(
+            query=query,
+            mark_text=mark_text,
+            owner_name=owner_name,
+            serial_number=serial_number,
+            registration_number=registration_number,
+            international_class=international_class,
+            status_filter=status_filter,
+            offset=offset,
+            limit=limit,
+        )
+
+        raw = await self.make_request(body)
+        if raw.get("error", False) is True:
+            return raw
+
+        return self.parse_search_response(raw)
+
+    async def get_by_serial(self, serial_number: str) -> Dict[str, Any]:
+        """Get a trademark's search-index record by serial number.
+
+        Args:
+            serial_number: 8-digit application serial number
+
+        Returns:
+            {"results": [...], "total": N} or error dictionary
+        """
+        return await self.search(serial_number=serial_number, limit=1)
+
+    async def close(self):
+        """Close the client connections and clean up resources."""
+        logger.info("Closing tmsearch client connections")
+        await self.client.aclose()

--- a/src/patent_mcp_server/uspto/tmsearch_client.py
+++ b/src/patent_mcp_server/uspto/tmsearch_client.py
@@ -7,17 +7,18 @@ replacement at https://tmsearch.uspto.gov). This is the same risk profile as
 the PPUBS internal API used by ppubs_uspto_gov.py: it is not an official
 public API and may change or break without notice.
 
-CONTRACT STATUS (2026-06-10): BEST-EFFORT — NOT verified against the live
-service (this environment has no network access to uspto.gov hosts). The
-request body is an Elasticsearch-style query POSTed to SEARCH_PATH, based on
-public observations of the web app's network calls. Before relying on this
-client, confirm the request/response shape via browser dev tools on
-tmsearch.uspto.gov and adjust ONLY these three seams:
+CONTRACT STATUS (2026-06-10): VERIFIED LIVE. POST {TMSEARCH_BASE_URL}
+/prod-stage-v1-0-0/tmsearch with an Elasticsearch-style query body returns
+JSON. Response envelope (non-standard ES): {"took": N, "hits": {"totalValue":
+N, "hits": [{"id": "<serial>", "source": {...}}]}}. If the shape drifts
+again, the seams to fix are:
   - SEARCH_PATH (module constant below)
   - constants.TmSearchFields (index field names)
   - TmSearchClient.build_search_body / parse_search_response
 
-No API key is required.
+No API key is required. The service sits behind AWS WAF, which currently
+answers plain requests; if USPTO tightens it (403/202 challenge responses),
+set TMSEARCH_WAF_TOKEN to a browser session's "aws-waf-token" cookie value.
 """
 
 from typing import Any, Optional, Dict
@@ -39,8 +40,8 @@ from patent_mcp_server.constants import TmSearchFields, TrademarkDefaults
 logger = logging.getLogger('tmsearch_client')
 
 # POST target for the internal search API, relative to config.TMSEARCH_BASE_URL.
-# Single place to fix if the web app's endpoint moves.
-SEARCH_PATH = "/api-v1-0-0/tmsearch"
+# Single place to fix if the web app's endpoint moves. Verified live 2026-06-10.
+SEARCH_PATH = "/prod-stage-v1-0-0/tmsearch"
 
 
 class TmSearchClient:
@@ -56,11 +57,16 @@ class TmSearchClient:
     def __init__(self):
         self.headers = {
             "User-Agent": config.USER_AGENT,
-            "X-Requested-With": "XMLHttpRequest",
+            "Accept": "application/json, text/plain, */*",
             "Origin": config.TMSEARCH_BASE_URL,
-            "Referer": f"{config.TMSEARCH_BASE_URL}/search/search-information",
+            "Referer": f"{config.TMSEARCH_BASE_URL}/",
             "Content-Type": "application/json",
         }
+
+        # AWS WAF token cookie, if the user supplied one (see module docstring)
+        cookies = {}
+        if config.TMSEARCH_WAF_TOKEN:
+            cookies["aws-waf-token"] = config.TMSEARCH_WAF_TOKEN
 
         # Create a custom transport that logs all requests and responses
         transport = httpx.AsyncHTTPTransport()
@@ -68,6 +74,7 @@ class TmSearchClient:
 
         self.client = httpx.AsyncClient(
             headers=self.headers,
+            cookies=cookies,
             http2=True,
             follow_redirects=True,
             transport=logging_transport,
@@ -89,6 +96,7 @@ class TmSearchClient:
         owner_name: Optional[str] = None,
         serial_number: Optional[str] = None,
         registration_number: Optional[str] = None,
+        goods_services: Optional[str] = None,
         international_class: Optional[str] = None,
         status_filter: Optional[str] = None,
         offset: int = 0,
@@ -96,9 +104,8 @@ class TmSearchClient:
     ) -> Dict[str, Any]:
         """Construct the Elasticsearch-style request body.
 
-        BEST-EFFORT SHAPE — confirm against live tmsearch.uspto.gov network
-        calls before release (see module docstring). Pure function; fully
-        unit-testable offline.
+        Shape verified live 2026-06-10 (see module docstring). Pure function;
+        fully unit-testable offline.
 
         Args:
             query: Raw query string (Elasticsearch query_string syntax)
@@ -106,7 +113,9 @@ class TmSearchClient:
             owner_name: Owner name to match
             serial_number: Exact serial number
             registration_number: Exact registration number
-            international_class: Nice international class number (e.g. "9")
+            goods_services: Goods/services description terms to match
+            international_class: Nice international class number (e.g. "9");
+                zero-padded to 3 digits because the index stores "IC 009"
             status_filter: "live", "dead", or None for both
             offset: Pagination offset
             limit: Maximum results
@@ -132,9 +141,15 @@ class TmSearchClient:
             must.append({"term": {TmSearchFields.SERIAL_NUMBER: serial_number}})
         if registration_number:
             must.append({"term": {TmSearchFields.REGISTRATION_NUMBER: registration_number}})
+        if goods_services:
+            must.append({"match": {TmSearchFields.GOODS_AND_SERVICES: goods_services}})
 
         if international_class:
-            filters.append({"term": {TmSearchFields.INTERNATIONAL_CLASS: international_class}})
+            # Index values look like "IC 025"; the term must be zero-padded
+            class_term = str(international_class).strip()
+            if class_term.isdigit():
+                class_term = class_term.zfill(3)
+            filters.append({"term": {TmSearchFields.INTERNATIONAL_CLASS: class_term}})
         if status_filter:
             status = status_filter.strip().lower()
             if status == "live":
@@ -159,10 +174,12 @@ class TmSearchClient:
 
     @staticmethod
     def parse_search_response(raw: Dict[str, Any]) -> Dict[str, Any]:
-        """Extract results and total from the Elasticsearch-style envelope.
+        """Extract results and total from the search response envelope.
 
-        Handles both ES7-style {"hits": {"total": {"value": N}, "hits": [...]}}
-        and older {"hits": {"total": N, "hits": [...]}} envelopes.
+        The live service (verified 2026-06-10) returns a non-standard
+        Elasticsearch envelope: {"hits": {"totalValue": N, "hits": [{"id":
+        "<serial>", "source": {...}}]}}. Standard ES envelopes
+        ({"total": {"value": N}}, "_source") are handled as fallbacks.
 
         Args:
             raw: Raw JSON response from the search endpoint
@@ -177,10 +194,17 @@ class TmSearchClient:
         hits = hits_obj.get("hits", [])
         results = []
         for hit in hits:
-            if isinstance(hit, dict):
-                results.append(hit.get("_source", hit))
+            if not isinstance(hit, dict):
+                continue
+            record = hit.get("source") or hit.get("_source") or hit
+            # The serial number lives in the hit id; make sure it's on the record
+            if isinstance(record, dict) and not record.get("id") and hit.get("id"):
+                record = {**record, "id": hit["id"]}
+            results.append(record)
 
-        total = hits_obj.get("total", len(results))
+        total = hits_obj.get("totalValue")
+        if total is None:
+            total = hits_obj.get("total", len(results))
         if isinstance(total, dict):
             total = total.get("value", len(results))
 
@@ -214,8 +238,39 @@ class TmSearchClient:
                 json=body,
                 timeout=config.REQUEST_TIMEOUT
             )
+
+            # AWS WAF rejections surface as 403 (blocked) or 202 (challenge)
+            if response.status_code in (202, 403):
+                logger.error(f"AWS WAF rejection: {response.status_code}")
+                error = ApiError.from_http_error(
+                    status_code=response.status_code,
+                    response_text=response.text[:500]
+                )
+                error["hint"] = (
+                    "tmsearch.uspto.gov rejected the request at its AWS WAF "
+                    "layer. Open https://tmsearch.uspto.gov in a browser, copy "
+                    "the 'aws-waf-token' cookie value, and set the "
+                    "TMSEARCH_WAF_TOKEN environment variable (token lasts ~4 "
+                    "days). For authoritative status of a known mark, "
+                    "tsdr_get_trademark_status does not use this service."
+                )
+                return error
+
             response.raise_for_status()
-            return response.json()
+
+            try:
+                return response.json()
+            except Exception:
+                # A 200 with non-JSON content is also a WAF challenge page
+                return ApiError.create(
+                    message=(
+                        "tmsearch.uspto.gov returned a non-JSON response "
+                        "(likely an AWS WAF challenge page). Set "
+                        "TMSEARCH_WAF_TOKEN from a browser session and retry."
+                    ),
+                    status_code=response.status_code,
+                    error_code="WAF_CHALLENGE",
+                )
 
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
@@ -247,6 +302,7 @@ class TmSearchClient:
         owner_name: Optional[str] = None,
         serial_number: Optional[str] = None,
         registration_number: Optional[str] = None,
+        goods_services: Optional[str] = None,
         international_class: Optional[str] = None,
         status_filter: Optional[str] = None,
         offset: int = 0,
@@ -263,6 +319,7 @@ class TmSearchClient:
             owner_name=owner_name,
             serial_number=serial_number,
             registration_number=registration_number,
+            goods_services=goods_services,
             international_class=international_class,
             status_filter=status_filter,
             offset=offset,

--- a/src/patent_mcp_server/uspto/tsdr_client.py
+++ b/src/patent_mcp_server/uspto/tsdr_client.py
@@ -5,17 +5,21 @@ This module provides access to the official TSDR API for trademark case status,
 prosecution documents, and mark images.
 
 Base URL: https://tsdrapi.uspto.gov/ts/cd
-Authentication: USPTO-API-KEY header (key issued via USPTO.gov account; the ODP
-key is used as a fallback — see config.TSDR_API_KEY).
+Authentication: USPTO-API-KEY header. IMPORTANT: TSDR issues its OWN API key
+(https://account.uspto.gov/profile/api-manager, "TSDR API" product). The ODP
+key passes the gateway's auth check but the backend returns 404 for every
+request ("BACKEND RESPONSE STATUS: 404") — if you see that, you need a TSDR
+key, not an ODP key.
 
-Rate limits (per API key, enforced by USPTO):
-  - 60 requests/minute for general (JSON/XML) requests
-  - 4 requests/minute for PDF/ZIP document bundle downloads
+Rate limits (per API key, enforced by USPTO), peak hours 5am-10pm ET:
+  - 60 requests/minute for general (JSON/XML) requests (120/min off-peak)
+  - 4 requests/minute for PDF/ZIP document bundle downloads (12/min off-peak)
 """
 
 import asyncio
 import base64
-from typing import Any, Optional, Dict, Union
+import xml.etree.ElementTree as ET
+from typing import Any, Optional, Dict, List, Union
 import httpx
 import logging
 from tenacity import (
@@ -28,10 +32,13 @@ from tenacity import (
 from patent_mcp_server.util.logging import LoggingTransport
 from patent_mcp_server.util.errors import ApiError
 from patent_mcp_server.config import config
-from patent_mcp_server.constants import Defaults
+from patent_mcp_server.constants import Defaults, TrademarkDefaults
 
 # Set up logging
 logger = logging.getLogger('tsdr_client')
+
+# Namespace of the TSDR document-list XML (verified live 2026-06-10)
+DOCUMENT_LIST_NS = "urn:us:gov:doc:uspto:trademark"
 
 
 class TSDRClient:
@@ -79,18 +86,28 @@ class TSDRClient:
         retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
         reraise=True
     )
-    async def _get(self, url: str) -> Union[httpx.Response, Dict[str, Any]]:
+    async def _get(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Union[httpx.Response, Dict[str, Any]]:
         """Perform a GET with retry and 429 (rate limit) handling.
 
         TSDR enforces 60 req/min generally and 4 req/min for PDF/ZIP, so the
         429 path here will fire under normal document-heavy usage.
+
+        Args:
+            url: Request URL
+            headers: Optional extra headers (merged over the client defaults)
 
         Returns:
             httpx.Response on success/HTTP error, or an ApiError dict on
             unexpected failure.
         """
         try:
-            response = await self.client.get(url, timeout=config.REQUEST_TIMEOUT)
+            response = await self.client.get(
+                url, headers=headers, timeout=config.REQUEST_TIMEOUT
+            )
 
             if response.status_code == 429:
                 wait_time = int(
@@ -101,7 +118,9 @@ class TSDRClient:
                 ) + 1
                 logger.info(f"TSDR rate limited, waiting {wait_time} seconds")
                 await asyncio.sleep(wait_time)
-                response = await self.client.get(url, timeout=config.REQUEST_TIMEOUT)
+                response = await self.client.get(
+                    url, headers=headers, timeout=config.REQUEST_TIMEOUT
+                )
 
             return response
 
@@ -112,8 +131,31 @@ class TSDRClient:
             logger.error(f"Request error: {str(e)}")
             return ApiError.from_exception(e, f"Request to {url} failed")
 
+    @staticmethod
+    def _auth_hint(status_code: int, response_text: str) -> Optional[str]:
+        """Map TSDR auth failures to an actionable hint, or None."""
+        if status_code == 401:
+            return (
+                "TSDR requires an API key in the USPTO-API-KEY header. Request "
+                "one at https://account.uspto.gov/profile/api-manager (select "
+                "the 'TSDR API' product) and set TSDR_API_KEY."
+            )
+        if status_code == 404 and "BACKEND RESPONSE STATUS" in (response_text or ""):
+            return (
+                "TSDR accepted the API key at its gateway but the backend "
+                "returned 404 for the request. This is the signature of using "
+                "an ODP API key — TSDR issues its own key. Request a TSDR key "
+                "at https://account.uspto.gov/profile/api-manager (select the "
+                "'TSDR API' product) and set TSDR_API_KEY. If you already use "
+                "a TSDR key, the case may not exist."
+            )
+        return None
+
     async def _make_json_request(self, url: str) -> Dict[str, Any]:
         """Make a GET request expecting a JSON response.
+
+        TSDR's /info endpoints return XML by default and JSON via content
+        negotiation, so the Accept header is set explicitly.
 
         Args:
             url: Request URL
@@ -123,23 +165,27 @@ class TSDRClient:
         """
         logger.info(f"Making TSDR JSON request to {url}")
 
-        response = await self._get(url)
+        response = await self._get(url, headers={"Accept": "application/json"})
         if isinstance(response, dict):
             return response  # Already an error dict
 
         if response.status_code != 200:
             try:
                 error_json = response.json()
-                return ApiError.from_http_error(
+                error = ApiError.from_http_error(
                     status_code=response.status_code,
                     response_text=response.text,
                     response_json=error_json
                 )
             except Exception:
-                return ApiError.from_http_error(
+                error = ApiError.from_http_error(
                     status_code=response.status_code,
                     response_text=response.text
                 )
+            hint = self._auth_hint(response.status_code, response.text)
+            if hint:
+                error["hint"] = hint
+            return error
 
         try:
             return response.json()
@@ -165,12 +211,30 @@ class TSDRClient:
             return response  # Already an error dict
 
         if response.status_code != 200:
-            return ApiError.from_http_error(
+            error = ApiError.from_http_error(
                 status_code=response.status_code,
                 response_text=response.text
             )
+            hint = self._auth_hint(response.status_code, response.text)
+            if hint:
+                error["hint"] = hint
+            return error
 
         content = response.content
+        if len(content) > TrademarkDefaults.MAX_BINARY_BYTES:
+            # Full file wrappers run to tens of MB; base64 of that would
+            # overwhelm the MCP response (and any LLM context window)
+            return ApiError.create(
+                message=(
+                    f"Document bundle is {len(content):,} bytes, above the "
+                    f"{TrademarkDefaults.MAX_BINARY_BYTES:,}-byte response "
+                    "limit. Narrow the request with document_type and/or "
+                    "date_from/date_to — use tsdr_list_trademark_documents "
+                    "first to see what exists and pick a filter."
+                ),
+                status_code=413,
+                error_code="RESPONSE_TOO_LARGE",
+            )
         b64_content = base64.b64encode(content).decode('utf-8')
 
         return {
@@ -195,9 +259,10 @@ class TSDRClient:
                 "Provide exactly one of serial_number or registration_number",
                 "serial_number"
             )
+        # /info returns XML by default; JSON comes via the Accept header
         if serial_number:
-            return f"{config.TSDR_BASE_URL}/casestatus/sn{serial_number}/info.json"
-        return f"{config.TSDR_BASE_URL}/casestatus/rn{registration_number}/info.json"
+            return f"{config.TSDR_BASE_URL}/casestatus/sn{serial_number}/info"
+        return f"{config.TSDR_BASE_URL}/casestatus/rn{registration_number}/info"
 
     async def get_case_status(
         self,
@@ -217,6 +282,73 @@ class TSDRClient:
         if isinstance(url, dict):
             return url
         return await self._make_json_request(url)
+
+    @staticmethod
+    def _parse_document_list_xml(xml_text: str) -> Dict[str, Any]:
+        """Parse the TSDR document-list XML into a list of dicts.
+
+        The /casedocs/{caseid}/info endpoint serves XML only (it answers
+        406 to Accept: application/json — verified live 2026-06-10). The
+        response is a flat <DocumentList><Document>...</Document>... tree
+        in the urn:us:gov:doc:uspto:trademark namespace; each Document's
+        child elements become dict keys (PageMediaTypeList collapses to a
+        list of media type names).
+
+        Args:
+            xml_text: Raw XML response body
+
+        Returns:
+            {"results": [...], "total": N} or error dictionary
+        """
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError as e:
+            return ApiError.from_exception(e, "Failed to parse TSDR document list XML")
+
+        ns = {"tm": DOCUMENT_LIST_NS}
+        results: List[Dict[str, Any]] = []
+        for doc in root.findall("tm:Document", ns):
+            record: Dict[str, Any] = {}
+            for child in doc:
+                tag = child.tag.split("}", 1)[-1]  # strip namespace
+                if tag == "PageMediaTypeList":
+                    record[tag] = [el.text for el in child]
+                else:
+                    record[tag] = child.text
+            results.append(record)
+
+        return {"results": results, "total": len(results)}
+
+    async def list_case_documents(self, serial_number: str) -> Dict[str, Any]:
+        """List prosecution document metadata for a trademark case.
+
+        Returns document descriptions, types, and dates WITHOUT downloading
+        content, so it is not subject to the 4 req/min PDF rate limit. Use
+        this to find what exists before downloading a filtered bundle.
+
+        Args:
+            serial_number: 8-digit application serial number
+
+        Returns:
+            {"results": [...], "total": N} or error dictionary
+        """
+        url = f"{config.TSDR_BASE_URL}/casedocs/sn{serial_number}/info"
+
+        response = await self._get(url)
+        if isinstance(response, dict):
+            return response  # Already an error dict
+
+        if response.status_code != 200:
+            error = ApiError.from_http_error(
+                status_code=response.status_code,
+                response_text=response.text
+            )
+            hint = self._auth_hint(response.status_code, response.text)
+            if hint:
+                error["hint"] = hint
+            return error
+
+        return self._parse_document_list_xml(response.text)
 
     async def download_case_documents(
         self,

--- a/src/patent_mcp_server/uspto/tsdr_client.py
+++ b/src/patent_mcp_server/uspto/tsdr_client.py
@@ -1,0 +1,268 @@
+"""
+USPTO TSDR (Trademark Status and Document Retrieval) API Module (tsdrapi.uspto.gov)
+
+This module provides access to the official TSDR API for trademark case status,
+prosecution documents, and mark images.
+
+Base URL: https://tsdrapi.uspto.gov/ts/cd
+Authentication: USPTO-API-KEY header (key issued via USPTO.gov account; the ODP
+key is used as a fallback — see config.TSDR_API_KEY).
+
+Rate limits (per API key, enforced by USPTO):
+  - 60 requests/minute for general (JSON/XML) requests
+  - 4 requests/minute for PDF/ZIP document bundle downloads
+"""
+
+import asyncio
+import base64
+from typing import Any, Optional, Dict, Union
+import httpx
+import logging
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+)
+
+from patent_mcp_server.util.logging import LoggingTransport
+from patent_mcp_server.util.errors import ApiError
+from patent_mcp_server.config import config
+from patent_mcp_server.constants import Defaults
+
+# Set up logging
+logger = logging.getLogger('tsdr_client')
+
+
+class TSDRClient:
+    """Client for the USPTO TSDR API at tsdrapi.uspto.gov.
+
+    Provides trademark case status (JSON), document bundles (PDF), and
+    mark images. Requires an API key sent as the USPTO-API-KEY header.
+
+    Supports context manager protocol for proper resource cleanup.
+    """
+
+    def __init__(self):
+        self.headers = {
+            "User-Agent": config.USER_AGENT,
+            "USPTO-API-KEY": config.TSDR_API_KEY if config.TSDR_API_KEY else ""
+        }
+
+        # Create a custom transport that logs all requests and responses
+        transport = httpx.AsyncHTTPTransport()
+        logging_transport = LoggingTransport(transport)
+
+        self.client = httpx.AsyncClient(
+            headers=self.headers,
+            http2=True,
+            follow_redirects=True,
+            transport=logging_transport,
+            timeout=config.REQUEST_TIMEOUT,
+        )
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit with cleanup."""
+        await self.close()
+
+    @retry(
+        stop=stop_after_attempt(config.MAX_RETRIES),
+        wait=wait_exponential(
+            multiplier=config.RETRY_DELAY,
+            min=config.RETRY_MIN_WAIT,
+            max=config.RETRY_MAX_WAIT
+        ),
+        retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+        reraise=True
+    )
+    async def _get(self, url: str) -> Union[httpx.Response, Dict[str, Any]]:
+        """Perform a GET with retry and 429 (rate limit) handling.
+
+        TSDR enforces 60 req/min generally and 4 req/min for PDF/ZIP, so the
+        429 path here will fire under normal document-heavy usage.
+
+        Returns:
+            httpx.Response on success/HTTP error, or an ApiError dict on
+            unexpected failure.
+        """
+        try:
+            response = await self.client.get(url, timeout=config.REQUEST_TIMEOUT)
+
+            if response.status_code == 429:
+                wait_time = int(
+                    response.headers.get(
+                        "Retry-After",
+                        Defaults.RATE_LIMIT_RETRY_DELAY
+                    )
+                ) + 1
+                logger.info(f"TSDR rate limited, waiting {wait_time} seconds")
+                await asyncio.sleep(wait_time)
+                response = await self.client.get(url, timeout=config.REQUEST_TIMEOUT)
+
+            return response
+
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            logger.warning(f"Network error (will retry): {str(e)}")
+            raise  # Let tenacity handle the retry
+        except Exception as e:
+            logger.error(f"Request error: {str(e)}")
+            return ApiError.from_exception(e, f"Request to {url} failed")
+
+    async def _make_json_request(self, url: str) -> Dict[str, Any]:
+        """Make a GET request expecting a JSON response.
+
+        Args:
+            url: Request URL
+
+        Returns:
+            Parsed JSON dictionary or error dictionary
+        """
+        logger.info(f"Making TSDR JSON request to {url}")
+
+        response = await self._get(url)
+        if isinstance(response, dict):
+            return response  # Already an error dict
+
+        if response.status_code != 200:
+            try:
+                error_json = response.json()
+                return ApiError.from_http_error(
+                    status_code=response.status_code,
+                    response_text=response.text,
+                    response_json=error_json
+                )
+            except Exception:
+                return ApiError.from_http_error(
+                    status_code=response.status_code,
+                    response_text=response.text
+                )
+
+        try:
+            return response.json()
+        except Exception as e:
+            return ApiError.from_exception(e, "TSDR returned non-JSON response")
+
+    async def _make_binary_request(self, url: str, filename: str) -> Dict[str, Any]:
+        """Make a GET request expecting binary content (PDF or image).
+
+        Args:
+            url: Request URL
+            filename: Filename to report in the response
+
+        Returns:
+            Dictionary with base64-encoded content or error dictionary:
+            {"success": True, "filename": ..., "content_type": ...,
+             "content": <base64>, "size_bytes": N}
+        """
+        logger.info(f"Making TSDR binary request to {url}")
+
+        response = await self._get(url)
+        if isinstance(response, dict):
+            return response  # Already an error dict
+
+        if response.status_code != 200:
+            return ApiError.from_http_error(
+                status_code=response.status_code,
+                response_text=response.text
+            )
+
+        content = response.content
+        b64_content = base64.b64encode(content).decode('utf-8')
+
+        return {
+            "success": True,
+            "filename": filename,
+            "content_type": response.headers.get("content-type", "application/octet-stream"),
+            "content": b64_content,
+            "size_bytes": len(content),
+        }
+
+    def _status_url(
+        self,
+        serial_number: Optional[str],
+        registration_number: Optional[str]
+    ) -> Union[str, Dict[str, Any]]:
+        """Build the case-status URL for exactly one identifier.
+
+        Returns the URL string, or an ApiError dict if identifiers are invalid.
+        """
+        if bool(serial_number) == bool(registration_number):
+            return ApiError.validation_error(
+                "Provide exactly one of serial_number or registration_number",
+                "serial_number"
+            )
+        if serial_number:
+            return f"{config.TSDR_BASE_URL}/casestatus/sn{serial_number}/info.json"
+        return f"{config.TSDR_BASE_URL}/casestatus/rn{registration_number}/info.json"
+
+    async def get_case_status(
+        self,
+        serial_number: Optional[str] = None,
+        registration_number: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Get trademark case status by serial number or registration number.
+
+        Args:
+            serial_number: 8-digit application serial number
+            registration_number: Registration number
+
+        Returns:
+            Parsed TSDR status JSON or error dictionary
+        """
+        url = self._status_url(serial_number, registration_number)
+        if isinstance(url, dict):
+            return url
+        return await self._make_json_request(url)
+
+    async def download_case_documents(
+        self,
+        serial_number: str,
+        document_type: Optional[str] = None,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Download the prosecution document bundle for a trademark as PDF.
+
+        NOTE: TSDR limits PDF/ZIP downloads to 4 requests/minute per API key.
+
+        Args:
+            serial_number: 8-digit application serial number
+            document_type: Optional document type filter (e.g., "OOA" for
+                outgoing office actions, "SPE" for specimens)
+            date_from: Optional start date filter (YYYY-MM-DD)
+            date_to: Optional end date filter (YYYY-MM-DD)
+
+        Returns:
+            Dictionary with base64-encoded PDF content or error
+        """
+        params = [f"sn={serial_number}"]
+        if document_type:
+            params.append(f"type={document_type}")
+        if date_from:
+            params.append(f"fromDate={date_from}")
+        if date_to:
+            params.append(f"toDate={date_to}")
+
+        url = f"{config.TSDR_BASE_URL}/casedocs/bundle.pdf?{'&'.join(params)}"
+        return await self._make_binary_request(url, f"tm-{serial_number}-documents.pdf")
+
+    async def get_mark_image(self, serial_number: str) -> Dict[str, Any]:
+        """Get the mark image (drawing) for a trademark.
+
+        Args:
+            serial_number: 8-digit application serial number
+
+        Returns:
+            Dictionary with base64-encoded image content or error
+        """
+        url = f"{config.TSDR_BASE_URL}/rawImage/{serial_number}"
+        return await self._make_binary_request(url, f"tm-{serial_number}-mark")
+
+    async def close(self):
+        """Close the client connections and clean up resources."""
+        logger.info("Closing TSDR client connections")
+        await self.client.aclose()

--- a/src/patent_mcp_server/util/response.py
+++ b/src/patent_mcp_server/util/response.py
@@ -224,6 +224,95 @@ class ResponseEnvelope:
         )
 
 
+    @staticmethod
+    def from_tsdr(
+        raw_response: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Normalize a TSDR API response (single trademark record).
+
+        Args:
+            raw_response: Raw response from TSDR API
+
+        Returns:
+            Standardized response
+        """
+        # TSDR info.json format: {"trademarks": [{...}]} with one record
+        trademarks = raw_response.get("trademarks")
+        if isinstance(trademarks, list) and trademarks:
+            results = trademarks[0] if len(trademarks) == 1 else trademarks
+        else:
+            results = raw_response
+
+        return ResponseEnvelope.success(
+            results=results,
+            source="tsdr",
+            offset=0,
+            limit=1,
+        )
+
+    @staticmethod
+    def from_tmsearch(
+        parsed_response: Dict[str, Any],
+        offset: int = 0,
+        limit: int = 25,
+    ) -> Dict[str, Any]:
+        """Normalize a parsed tmsearch.uspto.gov response.
+
+        Args:
+            parsed_response: Output of TmSearchClient.parse_search_response,
+                shaped {"results": [...], "total": N}
+            offset: Requested offset
+            limit: Requested limit
+
+        Returns:
+            Standardized response
+        """
+        results = parsed_response.get("results", [])
+        total = parsed_response.get("total", len(results))
+
+        return ResponseEnvelope.success(
+            results=results,
+            source="tmsearch",
+            count=len(results) if isinstance(results, list) else 1,
+            total=total,
+            offset=offset,
+            limit=limit,
+        )
+
+    @staticmethod
+    def from_tm_assignment(
+        parsed_response: Dict[str, Any],
+        offset: int = 0,
+        limit: int = 25,
+    ) -> Dict[str, Any]:
+        """Normalize a trademark assignment search response.
+
+        Args:
+            parsed_response: Parsed response shaped {"results": [...], "total": N},
+                optionally with a "backend" key ("odp" or "legacy")
+            offset: Requested offset
+            limit: Requested limit
+
+        Returns:
+            Standardized response
+        """
+        results = parsed_response.get("results", [])
+        total = parsed_response.get("total", len(results))
+        metadata = None
+        if parsed_response.get("backend"):
+            metadata = {"backend": parsed_response["backend"]}
+
+        return ResponseEnvelope.success(
+            results=results,
+            source="tm_assignments",
+            count=len(results) if isinstance(results, list) else 1,
+            total=total,
+            offset=offset,
+            limit=limit,
+            metadata=metadata,
+        )
+
+
 def estimate_tokens(data: Any) -> int:
     """Estimate token count for a data structure.
 

--- a/src/patent_mcp_server/util/response.py
+++ b/src/patent_mcp_server/util/response.py
@@ -289,7 +289,7 @@ class ResponseEnvelope:
 
         Args:
             parsed_response: Parsed response shaped {"results": [...], "total": N},
-                optionally with a "backend" key ("odp" or "legacy")
+                optionally with a "backend" key (e.g. "assignment-center")
             offset: Requested offset
             limit: Requested limit
 

--- a/src/patent_mcp_server/util/validation.py
+++ b/src/patent_mcp_server/util/validation.py
@@ -43,6 +43,41 @@ class ApplicationNumberInput(BaseModel):
         return cleaned
 
 
+class TrademarkSerialInput(BaseModel):
+    """Validation model for trademark application serial numbers."""
+
+    serial_number: str = Field(..., min_length=1, description="Trademark serial number")
+
+    @field_validator('serial_number')
+    @classmethod
+    def validate_serial_number(cls, v: str) -> str:
+        """Validate and clean trademark serial number."""
+        # Remove slashes, commas, and spaces
+        cleaned = ''.join(c for c in str(v) if c.isdigit())
+        if not cleaned:
+            raise ValueError("Serial number must contain at least one digit")
+        if len(cleaned) != 8:
+            raise ValueError("Trademark serial number must be exactly 8 digits")
+        return cleaned
+
+
+class TrademarkRegistrationInput(BaseModel):
+    """Validation model for trademark registration numbers."""
+
+    registration_number: str = Field(..., min_length=1, description="Trademark registration number")
+
+    @field_validator('registration_number')
+    @classmethod
+    def validate_registration_number(cls, v: str) -> str:
+        """Validate and clean trademark registration number."""
+        cleaned = ''.join(c for c in str(v) if c.isdigit())
+        if not cleaned:
+            raise ValueError("Registration number must contain at least one digit")
+        if len(cleaned) > 8:
+            raise ValueError("Trademark registration number must be at most 8 digits")
+        return cleaned
+
+
 class SearchQueryInput(BaseModel):
     """Validation model for search queries."""
 
@@ -131,3 +166,43 @@ def validate_app_number(app_num: str) -> str:
         return validated.app_num
     except Exception as e:
         raise ValueError(f"Invalid application number: {str(e)}")
+
+
+def validate_serial_number(serial_number: str) -> str:
+    """
+    Validate and clean a trademark serial number.
+
+    Args:
+        serial_number: Raw serial number input
+
+    Returns:
+        Cleaned 8-digit serial number string
+
+    Raises:
+        ValueError: If serial number is invalid
+    """
+    try:
+        validated = TrademarkSerialInput(serial_number=serial_number)
+        return validated.serial_number
+    except Exception as e:
+        raise ValueError(f"Invalid trademark serial number: {str(e)}")
+
+
+def validate_registration_number(registration_number: str) -> str:
+    """
+    Validate and clean a trademark registration number.
+
+    Args:
+        registration_number: Raw registration number input
+
+    Returns:
+        Cleaned registration number string
+
+    Raises:
+        ValueError: If registration number is invalid
+    """
+    try:
+        validated = TrademarkRegistrationInput(registration_number=registration_number)
+        return validated.registration_number
+    except Exception as e:
+        raise ValueError(f"Invalid trademark registration number: {str(e)}")

--- a/test/fixtures/tm_assignment_responses.py
+++ b/test/fixtures/tm_assignment_responses.py
@@ -1,0 +1,43 @@
+"""Mock responses for trademark assignment search (ODP and legacy XML)."""
+
+# ODP-style JSON bag
+MOCK_TM_ASSIGNMENT_ODP_RESPONSE = {
+    "count": 1,
+    "trademarkAssignmentDataBag": [
+        {
+            "reelNumber": "1234",
+            "frameNumber": "0567",
+            "conveyanceText": "ASSIGNS THE ENTIRE INTEREST",
+            "recordedDate": "2015-06-01",
+            "assignors": [{"name": "Old Owner Corp"}],
+            "assignees": [{"name": "New Owner LLC"}],
+            "registrationNumber": "3500027",
+        }
+    ],
+}
+
+# Legacy assignment-api.uspto.gov Solr-style XML
+MOCK_TM_ASSIGNMENT_LEGACY_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <lst name="responseHeader">
+    <int name="status">0</int>
+  </lst>
+  <result name="response" numFound="2" start="0">
+    <doc>
+      <str name="reelNo">1234</str>
+      <str name="frameNo">0567</str>
+      <str name="conveyanceText">ASSIGNS THE ENTIRE INTEREST</str>
+      <date name="recordedDate">2015-06-01T00:00:00Z</date>
+      <arr name="assignorName"><str>Old Owner Corp</str></arr>
+      <arr name="assigneeName"><str>New Owner LLC</str></arr>
+    </doc>
+    <doc>
+      <str name="reelNo">5678</str>
+      <str name="frameNo">0890</str>
+      <str name="conveyanceText">SECURITY INTEREST</str>
+      <arr name="assignorName"><str>New Owner LLC</str></arr>
+      <arr name="assigneeName"><str>Bank of Testing</str></arr>
+    </doc>
+  </result>
+</response>
+"""

--- a/test/fixtures/tm_assignment_responses.py
+++ b/test/fixtures/tm_assignment_responses.py
@@ -1,43 +1,66 @@
-"""Mock responses for trademark assignment search (ODP and legacy XML)."""
+"""Mock responses for trademark assignment search (USPTO Assignment Center).
 
-# ODP-style JSON bag
-MOCK_TM_ASSIGNMENT_ODP_RESPONSE = {
-    "count": 1,
-    "trademarkAssignmentDataBag": [
-        {
-            "reelNumber": "1234",
-            "frameNumber": "0567",
-            "conveyanceText": "ASSIGNS THE ENTIRE INTEREST",
-            "recordedDate": "2015-06-01",
-            "assignors": [{"name": "Old Owner Corp"}],
-            "assignees": [{"name": "New Owner LLC"}],
-            "registrationNumber": "3500027",
-        }
-    ],
-}
-
-# Legacy assignment-api.uspto.gov Solr-style XML
-MOCK_TM_ASSIGNMENT_LEGACY_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<response>
-  <lst name="responseHeader">
-    <int name="status">0</int>
-  </lst>
-  <result name="response" numFound="2" start="0">
-    <doc>
-      <str name="reelNo">1234</str>
-      <str name="frameNo">0567</str>
-      <str name="conveyanceText">ASSIGNS THE ENTIRE INTEREST</str>
-      <date name="recordedDate">2015-06-01T00:00:00Z</date>
-      <arr name="assignorName"><str>Old Owner Corp</str></arr>
-      <arr name="assigneeName"><str>New Owner LLC</str></arr>
-    </doc>
-    <doc>
-      <str name="reelNo">5678</str>
-      <str name="frameNo">0890</str>
-      <str name="conveyanceText">SECURITY INTEREST</str>
-      <arr name="assignorName"><str>New Owner LLC</str></arr>
-      <arr name="assigneeName"><str>Bank of Testing</str></arr>
-    </doc>
-  </result>
-</response>
+Shape captured live from
+POST https://assignmentcenter.uspto.gov/ipas/search/api/v2/public/trademark/exportTradeMarkData
+on 2026-06-10.
 """
+
+# The API returns a list with one element: {"searchCriteria": [...], "data": [...]}
+MOCK_TM_ASSIGNMENT_RESPONSE = [
+    {
+        "searchCriteria": [
+            {"property": "New Owner LLC", "searchBy": "assigneeName"},
+            {"property": "25", "searchBy": "rowsNeeded"},
+        ],
+        "data": [
+            {
+                "reelNumber": 1234,
+                "frameNumber": "0567",
+                "assignorExecutionDate": "06/01/2015",
+                "correspondentName": "EXAMPLE LAW LLP",
+                "domesticRepresentative": None,
+                "assignors": [
+                    {"name": "Old Owner Corp", "executionDate": "06/01/2015"}
+                ],
+                "assignees": ["New Owner LLC"],
+                "noOfProperties": 1,
+                "properties": [
+                    {
+                        "serialNumber": "78787878",
+                        "registrationNumber": "3500027",
+                        "markName": "EXAMPLE MARK",
+                    }
+                ],
+            },
+            {
+                "reelNumber": 5678,
+                "frameNumber": "0890",
+                "assignorExecutionDate": "03/15/2020",
+                "correspondentName": "EXAMPLE LAW LLP",
+                "domesticRepresentative": None,
+                "assignors": [
+                    {"name": "New Owner LLC", "executionDate": "03/15/2020"}
+                ],
+                "assignees": ["Bank of Testing"],
+                "noOfProperties": 1,
+                "properties": [
+                    {
+                        "serialNumber": "78787878",
+                        "registrationNumber": "3500027",
+                        "markName": "EXAMPLE MARK",
+                    }
+                ],
+            },
+        ],
+    }
+]
+
+MOCK_TM_ASSIGNMENT_EMPTY_RESPONSE = [
+    {
+        "searchCriteria": [
+            {"property": "Nonexistent Co", "searchBy": "assigneeName"},
+            {"property": "25", "searchBy": "rowsNeeded"},
+        ],
+        "data": [],
+    }
+]

--- a/test/fixtures/tmsearch_responses.py
+++ b/test/fixtures/tmsearch_responses.py
@@ -1,0 +1,51 @@
+"""Mock responses for the tmsearch.uspto.gov internal search API."""
+
+# Elasticsearch-style (ES7) envelope with total as an object
+MOCK_TMSEARCH_RESPONSE = {
+    "took": 12,
+    "hits": {
+        "total": {"value": 2, "relation": "eq"},
+        "hits": [
+            {
+                "_id": "78787878",
+                "_source": {
+                    "id": "78787878",
+                    "wordmark": "TESTMARK",
+                    "ownerFullText": "Test Trademark Owner LLC",
+                    "registrationId": "3500027",
+                    "internationalClasses": ["009"],
+                    "alive": True,
+                    "markType": "TRADEMARK",
+                    "registrationDate": "2008-09-09",
+                },
+            },
+            {
+                "_id": "87654321",
+                "_source": {
+                    "id": "87654321",
+                    "wordmark": "TESTMARK PRO",
+                    "ownerFullText": "Another Owner Inc",
+                    "internationalClasses": ["009", "042"],
+                    "alive": False,
+                    "markType": "TRADEMARK",
+                    "abandonDate": "2019-03-04",
+                },
+            },
+        ],
+    },
+}
+
+# Older envelope style with total as a plain int
+MOCK_TMSEARCH_RESPONSE_INT_TOTAL = {
+    "hits": {
+        "total": 1,
+        "hits": [
+            {"_source": {"id": "78787878", "wordmark": "TESTMARK", "alive": True}}
+        ],
+    }
+}
+
+MOCK_TMSEARCH_EMPTY_RESPONSE = {
+    "took": 3,
+    "hits": {"total": {"value": 0, "relation": "eq"}, "hits": []},
+}

--- a/test/fixtures/tmsearch_responses.py
+++ b/test/fixtures/tmsearch_responses.py
@@ -1,36 +1,68 @@
-"""Mock responses for the tmsearch.uspto.gov internal search API."""
+"""Mock responses for the tmsearch.uspto.gov internal search API.
 
-# Elasticsearch-style (ES7) envelope with total as an object
+The live envelope (verified 2026-06-10) is a non-standard Elasticsearch
+shape: hits.totalValue (int) and hit "source"/"id" (no underscores).
+"""
+
+# Live envelope shape from POST /prod-stage-v1-0-0/tmsearch
 MOCK_TMSEARCH_RESPONSE = {
     "took": 12,
+    "timedOut": False,
+    "shardsTotal": 5,
+    "shardsSuccessful": 5,
     "hits": {
-        "total": {"value": 2, "relation": "eq"},
+        "totalValue": 2,
+        "totalRelation": "eq",
+        "maxScore": 16.35,
         "hits": [
             {
-                "_id": "78787878",
-                "_source": {
+                "index": "tmsearch-index",
+                "type": "_doc",
+                "id": "78787878",
+                "score": 16.35,
+                "source": {
                     "id": "78787878",
                     "wordmark": "TESTMARK",
+                    "ownerName": ["Test Trademark Owner LLC (CORPORATION; DELAWARE, USA)"],
                     "ownerFullText": "Test Trademark Owner LLC",
                     "registrationId": "3500027",
-                    "internationalClasses": ["009"],
+                    "internationalClass": ["IC 009"],
                     "alive": True,
                     "markType": "TRADEMARK",
                     "registrationDate": "2008-09-09",
+                    "statusCode": "700",
+                    "statusDescription": "REGISTERED",
                 },
             },
             {
-                "_id": "87654321",
-                "_source": {
+                "index": "tmsearch-index",
+                "type": "_doc",
+                "id": "87654321",
+                "score": 12.01,
+                "source": {
                     "id": "87654321",
                     "wordmark": "TESTMARK PRO",
                     "ownerFullText": "Another Owner Inc",
-                    "internationalClasses": ["009", "042"],
+                    "internationalClass": ["IC 009", "IC 042"],
                     "alive": False,
                     "markType": "TRADEMARK",
                     "abandonDate": "2019-03-04",
                 },
             },
+        ],
+    },
+}
+
+# Standard ES7 envelope (fallback handling: total object + _source)
+MOCK_TMSEARCH_ES7_RESPONSE = {
+    "took": 12,
+    "hits": {
+        "total": {"value": 1, "relation": "eq"},
+        "hits": [
+            {
+                "_id": "78787878",
+                "_source": {"id": "78787878", "wordmark": "TESTMARK", "alive": True},
+            }
         ],
     },
 }
@@ -47,5 +79,5 @@ MOCK_TMSEARCH_RESPONSE_INT_TOTAL = {
 
 MOCK_TMSEARCH_EMPTY_RESPONSE = {
     "took": 3,
-    "hits": {"total": {"value": 0, "relation": "eq"}, "hits": []},
+    "hits": {"totalValue": 0, "totalRelation": "eq", "hits": []},
 }

--- a/test/fixtures/tsdr_responses.py
+++ b/test/fixtures/tsdr_responses.py
@@ -1,0 +1,44 @@
+"""Mock responses for the TSDR API (tsdrapi.uspto.gov)."""
+import base64
+
+# Trimmed shape of /casestatus/sn{N}/info.json
+MOCK_TSDR_STATUS_RESPONSE = {
+    "trademarks": [
+        {
+            "status": {
+                "serialNumber": "78787878",
+                "usRegistrationNumber": "3500027",
+                "markElement": "TESTMARK",
+                "status": 700,
+                "statusDescription": "Registered",
+                "statusDate": "2008-09-09",
+                "filingDate": "2006-01-11",
+                "usRegistrationDate": "2008-09-09",
+                "standardCharacterClaim": True,
+                "markDrawingCode": "4000",
+            },
+            "parties": {
+                "owners": [
+                    {
+                        "name": "Test Trademark Owner LLC",
+                        "address": {"city": "Alexandria", "state": "VA"},
+                    }
+                ]
+            },
+            "gsList": [
+                {
+                    "internationalClasses": ["009"],
+                    "description": "Computer software for testing",
+                }
+            ],
+        }
+    ]
+}
+
+# Minimal valid PDF for binary-response tests
+MOCK_TSDR_PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< >>\n%%EOF"
+MOCK_TSDR_PDF_CONTENT = base64.b64encode(MOCK_TSDR_PDF_BYTES).decode("utf-8")
+
+# Minimal PNG header bytes for image tests
+MOCK_TSDR_IMAGE_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+MOCK_TSDR_IMAGE_CONTENT = base64.b64encode(MOCK_TSDR_IMAGE_BYTES).decode("utf-8")

--- a/test/fixtures/tsdr_responses.py
+++ b/test/fixtures/tsdr_responses.py
@@ -42,3 +42,8 @@ MOCK_TSDR_PDF_CONTENT = base64.b64encode(MOCK_TSDR_PDF_BYTES).decode("utf-8")
 # Minimal PNG header bytes for image tests
 MOCK_TSDR_IMAGE_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
 MOCK_TSDR_IMAGE_CONTENT = base64.b64encode(MOCK_TSDR_IMAGE_BYTES).decode("utf-8")
+
+# Document-list XML, shape captured live from
+# GET /ts/cd/casedocs/sn74612654/info on 2026-06-10 (namespace and field
+# names verbatim; this endpoint serves XML only and 406es on JSON)
+MOCK_TSDR_DOCUMENT_LIST_XML = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?><DocumentList xmlns="urn:us:gov:doc:uspto:trademark"><Document><SerialNumber>78787878</SerialNumber><DocumentTypeCode>OOA</DocumentTypeCode><DocumentTypeCodeDescriptionText>Offc Action Outgoing</DocumentTypeCodeDescriptionText><CategoryTypeCode>O</CategoryTypeCode><CategoryTypeCodeDescriptionText>Outgoing</CategoryTypeCodeDescriptionText><MailRoomDate>2020-01-15-05:00</MailRoomDate><ScanDateTime>2020-01-15T10:20:37.000-05:00</ScanDateTime><TotalPageQuantity>5</TotalPageQuantity><PageMediaTypeList><PageMediaTypeName>image/tiff</PageMediaTypeName></PageMediaTypeList></Document><Document><SerialNumber>78787878</SerialNumber><DocumentTypeCode>SPE</DocumentTypeCode><DocumentTypeCodeDescriptionText>Specimen</DocumentTypeCodeDescriptionText><CategoryTypeCode>I</CategoryTypeCode><CategoryTypeCodeDescriptionText>Incoming</CategoryTypeCodeDescriptionText><MailRoomDate>2019-08-01-04:00</MailRoomDate><ScanDateTime>2019-08-02T09:00:00.000-04:00</ScanDateTime><TotalPageQuantity>2</TotalPageQuantity><PageMediaTypeList><PageMediaTypeName>image/jpeg</PageMediaTypeName></PageMediaTypeList></Document></DocumentList>"""

--- a/test/test_trademark_integration.py
+++ b/test/test_trademark_integration.py
@@ -4,33 +4,37 @@ Skipped by default; run with: uv run pytest -m integration -k trademark
 
 Requirements:
   - Network access to uspto.gov hosts
-  - TSDR_API_KEY or USPTO_API_KEY in .env for TSDR and assignment tests
+  - TSDR_API_KEY in .env for the TSDR tests. NOTE: TSDR requires its own
+    key from account.uspto.gov/profile/api-manager ("TSDR API" product);
+    an ODP key passes the gateway but every request 404s.
 
-These tests double as live-contract verification for the two backends that
-could not be probed during development:
-  - tmsearch.uspto.gov (undocumented internal API — see tmsearch_client.py)
-  - trademark assignment search (ODP migration target vs legacy XML API)
-If the tmsearch tests fail with 400/404, inspect the web app's network
-calls and adjust SEARCH_PATH / TmSearchFields / build_search_body.
+tmsearch and Assignment Center contracts were verified live on 2026-06-10
+and need no API key. If the tmsearch tests start failing with 403/202, AWS
+WAF has been tightened — set TMSEARCH_WAF_TOKEN from a browser cookie.
 """
 import base64
+import os
 import pytest
 
 from patent_mcp_server import patents
-from patent_mcp_server.config import config
 
 # Long-registered, stable marks for lookups
-KNOWN_SERIAL = "78787878"          # TSDR's own documentation example
+KNOWN_SERIAL = "74612654"          # NIKE (word mark), registered 1996, live
+KNOWN_WORDMARK = "NIKE"
 
 
-requires_key = pytest.mark.skipif(
-    not config.TSDR_API_KEY,
-    reason="TSDR_API_KEY / USPTO_API_KEY not configured",
+# Keyed off the env var directly, NOT config.TSDR_API_KEY: the config falls
+# back to USPTO_API_KEY, but an ODP key cannot reach the TSDR backend (every
+# request 404s), so the fallback would make these tests fail, not run.
+requires_tsdr_key = pytest.mark.skipif(
+    not os.getenv("TSDR_API_KEY"),
+    reason="TSDR_API_KEY not configured (TSDR-specific key required; "
+           "the ODP key does not work for TSDR)",
 )
 
 
 @pytest.mark.integration
-@requires_key
+@requires_tsdr_key
 async def test_tsdr_status_by_serial_live():
     """TSDR returns a status record for a known serial number."""
     result = await patents.tsdr_get_trademark_status(serial_number=KNOWN_SERIAL)
@@ -44,11 +48,30 @@ async def test_tsdr_status_by_serial_live():
 
 
 @pytest.mark.integration
+@requires_tsdr_key
+async def test_tsdr_list_documents_live():
+    """TSDR lists prosecution document metadata (XML-only endpoint)."""
+    result = await patents.tsdr_list_trademark_documents(KNOWN_SERIAL)
+
+    assert result.get("error") is not True, result
+    assert result["success"] is True
+    assert result["total"] > 0
+    assert result["results"][0].get("DocumentTypeCode"), result["results"][0]
+
+
+@pytest.mark.integration
 @pytest.mark.slow
-@requires_key
+@requires_tsdr_key
 async def test_tsdr_document_bundle_live():
-    """TSDR document bundle downloads and decodes to a PDF."""
-    result = await patents.tsdr_download_trademark_documents(KNOWN_SERIAL)
+    """A filtered TSDR document bundle downloads and decodes to a PDF.
+
+    Filtered by document type because NIKE's full wrapper is ~13 MB —
+    over the MAX_BINARY_BYTES guard and a needless 4-req/min PDF spend.
+    ACR (Notice-Acceptance-Renewal) is a single-page document.
+    """
+    result = await patents.tsdr_download_trademark_documents(
+        KNOWN_SERIAL, document_type="ACR"
+    )
 
     assert result.get("error") is not True, result
     assert result["content_type"].startswith("application/pdf")
@@ -57,10 +80,9 @@ async def test_tsdr_document_bundle_live():
 
 @pytest.mark.integration
 async def test_tm_search_trademarks_live():
-    """tmsearch returns hits for a famous live mark (validates the probed
-    request body against the real internal API)."""
+    """tmsearch returns hits for a famous live mark."""
     result = await patents.tm_search_trademarks(
-        mark_text="NIKE", status_filter="live", limit=5
+        mark_text=KNOWN_WORDMARK, status_filter="live", limit=5
     )
 
     assert result.get("error") is not True, result
@@ -69,12 +91,33 @@ async def test_tm_search_trademarks_live():
 
 
 @pytest.mark.integration
-@requires_key
-async def test_tm_search_assignments_live():
-    """Assignment search answers from one of the two backends."""
-    result = await patents.tm_search_assignments(
-        assignee_name="Nike", limit=5
+async def test_tm_search_trademarks_class_filter_live():
+    """The international class filter narrows results (zero-padded term)."""
+    result = await patents.tm_search_trademarks(
+        owner_name="Nike", international_class="25", status_filter="live",
+        limit=5,
     )
 
     assert result.get("error") is not True, result
-    assert result["metadata"]["backend"] in ("odp", "legacy")
+    assert result["total"] > 0
+
+
+@pytest.mark.integration
+async def test_tm_get_trademark_live():
+    """Single-record lookup by serial number hits the live index."""
+    result = await patents.tm_get_trademark(KNOWN_SERIAL)
+
+    assert result.get("error") is not True, result
+    assert result["results"][0]["wordmark"] == KNOWN_WORDMARK
+
+
+@pytest.mark.integration
+async def test_tm_search_assignments_live():
+    """Assignment Center answers without an API key."""
+    result = await patents.tm_search_assignments(
+        assignee_name="Nike, Inc.", limit=5
+    )
+
+    assert result.get("error") is not True, result
+    assert result["metadata"]["backend"] == "assignment-center"
+    assert len(result["results"]) > 0

--- a/test/test_trademark_integration.py
+++ b/test/test_trademark_integration.py
@@ -1,0 +1,80 @@
+"""Integration tests for trademark tools (real API calls).
+
+Skipped by default; run with: uv run pytest -m integration -k trademark
+
+Requirements:
+  - Network access to uspto.gov hosts
+  - TSDR_API_KEY or USPTO_API_KEY in .env for TSDR and assignment tests
+
+These tests double as live-contract verification for the two backends that
+could not be probed during development:
+  - tmsearch.uspto.gov (undocumented internal API — see tmsearch_client.py)
+  - trademark assignment search (ODP migration target vs legacy XML API)
+If the tmsearch tests fail with 400/404, inspect the web app's network
+calls and adjust SEARCH_PATH / TmSearchFields / build_search_body.
+"""
+import base64
+import pytest
+
+from patent_mcp_server import patents
+from patent_mcp_server.config import config
+
+# Long-registered, stable marks for lookups
+KNOWN_SERIAL = "78787878"          # TSDR's own documentation example
+
+
+requires_key = pytest.mark.skipif(
+    not config.TSDR_API_KEY,
+    reason="TSDR_API_KEY / USPTO_API_KEY not configured",
+)
+
+
+@pytest.mark.integration
+@requires_key
+async def test_tsdr_status_by_serial_live():
+    """TSDR returns a status record for a known serial number."""
+    result = await patents.tsdr_get_trademark_status(serial_number=KNOWN_SERIAL)
+
+    assert result.get("error") is not True, result
+    assert result["success"] is True
+    assert result["source"] == "tsdr"
+    # The record should carry a status block with a serial number
+    record = result["results"]
+    assert record, "empty TSDR record"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@requires_key
+async def test_tsdr_document_bundle_live():
+    """TSDR document bundle downloads and decodes to a PDF."""
+    result = await patents.tsdr_download_trademark_documents(KNOWN_SERIAL)
+
+    assert result.get("error") is not True, result
+    assert result["content_type"].startswith("application/pdf")
+    assert base64.b64decode(result["content"]).startswith(b"%PDF")
+
+
+@pytest.mark.integration
+async def test_tm_search_trademarks_live():
+    """tmsearch returns hits for a famous live mark (validates the probed
+    request body against the real internal API)."""
+    result = await patents.tm_search_trademarks(
+        mark_text="NIKE", status_filter="live", limit=5
+    )
+
+    assert result.get("error") is not True, result
+    assert result["total"] > 0
+    assert len(result["results"]) > 0
+
+
+@pytest.mark.integration
+@requires_key
+async def test_tm_search_assignments_live():
+    """Assignment search answers from one of the two backends."""
+    result = await patents.tm_search_assignments(
+        assignee_name="Nike", limit=5
+    )
+
+    assert result.get("error") is not True, result
+    assert result["metadata"]["backend"] in ("odp", "legacy")

--- a/test/unit/test_ppubs_client.py
+++ b/test/unit/test_ppubs_client.py
@@ -521,3 +521,30 @@ async def test_run_query_does_not_mutate_template(ppubs_client):
 
     # Template must still hold its original q after both calls.
     assert ppubs_client.search_query["query"]["q"] == template_q_before
+
+
+@pytest.mark.unit
+async def test_ppubs_download_patent_pdf_tool_passes_full_signature():
+    """Regression: the tool must call download_image with all four arguments
+    (guid, image_location, page_count, document_type) — it previously passed
+    only (guid, type), raising TypeError at runtime."""
+    from patent_mcp_server import patents
+
+    patent_doc = MOCK_SEARCH_RESPONSE["docs"][0]
+    search_result = {"success": True, "patent": patent_doc}
+
+    with patch("patent_mcp_server.patents._search_patent_by_number",
+               new_callable=AsyncMock, return_value=search_result), \
+         patch.object(patents.ppubs_client, "download_image",
+                      new_callable=AsyncMock) as dl:
+        dl.return_value = {"success": True, "filename": "x.pdf",
+                           "content_type": "application/pdf", "content": ""}
+        result = await patents.ppubs_download_patent_pdf("9876543")
+
+    assert result["success"] is True
+    dl.assert_awaited_once_with(
+        patent_doc["guid"],
+        patent_doc["imageLocation"],
+        patent_doc["pageCount"],
+        patent_doc["type"],
+    )

--- a/test/unit/test_tm_assignment_client.py
+++ b/test/unit/test_tm_assignment_client.py
@@ -1,0 +1,184 @@
+"""Unit tests for TmAssignmentClient (ODP-first with legacy XML fallback)."""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from patent_mcp_server.uspto.tm_assignment_client import (
+    TmAssignmentClient, ODP_SEARCH_PATH, LEGACY_SEARCH_PATH
+)
+from patent_mcp_server.config import config
+
+from test.fixtures.tm_assignment_responses import (
+    MOCK_TM_ASSIGNMENT_ODP_RESPONSE,
+    MOCK_TM_ASSIGNMENT_LEGACY_XML,
+)
+
+
+@pytest.fixture
+async def tm_client():
+    """Create a TmAssignmentClient instance for testing."""
+    client = TmAssignmentClient()
+    yield client
+    await client.close()
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.text = text
+    if json_data is not None:
+        response.json.return_value = json_data
+        import json as _json
+        response.text = _json.dumps(json_data)
+    else:
+        response.json.side_effect = ValueError("no json")
+    return response
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_client_initialization():
+    """Client sends the X-API-KEY header for the ODP backend."""
+    client = TmAssignmentClient()
+
+    assert "X-API-KEY" in client.headers
+    assert client._backend is None
+
+    await client.close()
+
+
+@pytest.mark.unit
+async def test_client_context_manager():
+    async with TmAssignmentClient() as client:
+        assert client is not None
+
+
+# ============================================================================
+# Filter Validation Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_at_least_one_filter_required(tm_client):
+    """No filters at all returns a MISSING_FILTER error without a request."""
+    result = await tm_client.search_assignments()
+
+    assert result["error"] is True
+    assert result["error_code"] == "MISSING_FILTER"
+
+
+# ============================================================================
+# Backend Selection Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_odp_tried_first_and_used_on_success(tm_client):
+    """A working ODP endpoint is used and cached as the backend."""
+    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=MOCK_TM_ASSIGNMENT_ODP_RESPONSE)
+        result = await tm_client.search_assignments(registration_number="3500027")
+
+    assert result["backend"] == "odp"
+    assert tm_client._backend == "odp"
+    assert result["total"] == 1
+    assert result["results"][0]["reelNumber"] == "1234"
+
+    called_url = m.call_args[0][0]
+    assert called_url.startswith(f"{config.API_BASE_URL}{ODP_SEARCH_PATH}")
+
+
+@pytest.mark.unit
+async def test_404_triggers_legacy_fallback(tm_client):
+    """ODP 404 falls back to the legacy XML API."""
+    odp_404 = _mock_response(404, text="Not found")
+    legacy_ok = _mock_response(200, text=MOCK_TM_ASSIGNMENT_LEGACY_XML)
+
+    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
+        m.side_effect = [odp_404, legacy_ok]
+        result = await tm_client.search_assignments(assignee_name="New Owner LLC")
+
+    assert result["backend"] == "legacy"
+    assert tm_client._backend == "legacy"
+    assert result["total"] == 2
+    assert m.call_count == 2
+
+    legacy_url = m.call_args_list[1][0][0]
+    assert legacy_url.startswith(f"{config.TM_ASSIGNMENT_BASE_URL}{LEGACY_SEARCH_PATH}")
+
+
+@pytest.mark.unit
+async def test_legacy_backend_cached_skips_odp(tm_client):
+    """Once legacy is cached, ODP is not probed again."""
+    tm_client._backend = "legacy"
+
+    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, text=MOCK_TM_ASSIGNMENT_LEGACY_XML)
+        result = await tm_client.search_assignments(assignor_name="Old Owner Corp")
+
+    assert m.call_count == 1
+    assert result["backend"] == "legacy"
+    called_url = m.call_args[0][0]
+    assert called_url.startswith(config.TM_ASSIGNMENT_BASE_URL)
+
+
+@pytest.mark.unit
+async def test_odp_non_404_error_does_not_fall_back(tm_client):
+    """A real ODP error (e.g. 403) is surfaced, not masked by fallback."""
+    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(403, text="Forbidden")
+        result = await tm_client.search_assignments(registration_number="3500027")
+
+    assert result["error"] is True
+    assert result["status_code"] == 403
+    assert m.call_count == 1
+
+
+# ============================================================================
+# Legacy XML Parsing Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_parse_legacy_xml(tm_client):
+    """Solr-style XML docs are converted into dicts with arrays."""
+    parsed = tm_client._parse_legacy_xml(MOCK_TM_ASSIGNMENT_LEGACY_XML)
+
+    assert parsed["total"] == 2
+    first = parsed["results"][0]
+    assert first["reelNo"] == "1234"
+    assert first["assignorName"] == ["Old Owner Corp"]
+    assert first["assigneeName"] == ["New Owner LLC"]
+
+
+@pytest.mark.unit
+async def test_parse_legacy_xml_invalid(tm_client):
+    """Invalid XML returns an error dict."""
+    parsed = tm_client._parse_legacy_xml("this is not xml <<<")
+    assert parsed["error"] is True
+
+
+@pytest.mark.unit
+async def test_parse_legacy_xml_no_results(tm_client):
+    """XML without a result element returns empty results."""
+    parsed = tm_client._parse_legacy_xml("<response></response>")
+    assert parsed == {"results": [], "total": 0}
+
+
+# ============================================================================
+# ODP Query Building Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_odp_query_clauses(tm_client):
+    """All filters land in the Lucene q= parameter."""
+    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data={"count": 0, "results": []})
+        await tm_client.search_assignments(
+            serial_number="78787878",
+            assignee_name="New Owner LLC",
+        )
+
+    called_url = m.call_args[0][0]
+    assert "applicationNumberText%3A78787878" in called_url
+    assert "assigneeName" in called_url

--- a/test/unit/test_tm_assignment_client.py
+++ b/test/unit/test_tm_assignment_client.py
@@ -1,16 +1,16 @@
-"""Unit tests for TmAssignmentClient (ODP-first with legacy XML fallback)."""
+"""Unit tests for TmAssignmentClient (USPTO Assignment Center backend)."""
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 import httpx
 
 from patent_mcp_server.uspto.tm_assignment_client import (
-    TmAssignmentClient, ODP_SEARCH_PATH, LEGACY_SEARCH_PATH
+    TmAssignmentClient, SEARCH_PATH, MAX_ROWS_PER_REQUEST
 )
 from patent_mcp_server.config import config
 
 from test.fixtures.tm_assignment_responses import (
-    MOCK_TM_ASSIGNMENT_ODP_RESPONSE,
-    MOCK_TM_ASSIGNMENT_LEGACY_XML,
+    MOCK_TM_ASSIGNMENT_RESPONSE,
+    MOCK_TM_ASSIGNMENT_EMPTY_RESPONSE,
 )
 
 
@@ -41,11 +41,11 @@ def _mock_response(status_code=200, json_data=None, text=""):
 
 @pytest.mark.unit
 async def test_client_initialization():
-    """Client sends the X-API-KEY header for the ODP backend."""
+    """Assignment Center is a public API — no API key header is sent."""
     client = TmAssignmentClient()
 
-    assert "X-API-KEY" in client.headers
-    assert client._backend is None
+    assert "X-API-KEY" not in client.headers
+    assert client.headers["Content-Type"] == "application/json"
 
     await client.close()
 
@@ -70,115 +70,159 @@ async def test_at_least_one_filter_required(tm_client):
 
 
 # ============================================================================
-# Backend Selection Tests
+# Search Criteria Building Tests (pure function)
 # ============================================================================
 
 @pytest.mark.unit
-async def test_odp_tried_first_and_used_on_success(tm_client):
-    """A working ODP endpoint is used and cached as the backend."""
-    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
-        m.return_value = _mock_response(200, json_data=MOCK_TM_ASSIGNMENT_ODP_RESPONSE)
-        result = await tm_client.search_assignments(registration_number="3500027")
+def test_build_search_criteria_single_filter():
+    """A single filter maps to its Assignment Center searchBy name."""
+    criteria = TmAssignmentClient.build_search_criteria(
+        {"assignee_name": "New Owner LLC"}, offset=0, limit=25
+    )
 
-    assert result["backend"] == "odp"
-    assert tm_client._backend == "odp"
-    assert result["total"] == 1
-    assert result["results"][0]["reelNumber"] == "1234"
-
-    called_url = m.call_args[0][0]
-    assert called_url.startswith(f"{config.API_BASE_URL}{ODP_SEARCH_PATH}")
+    assert {"property": "New Owner LLC", "searchBy": "assigneeName"} in criteria
+    assert {"property": "25", "searchBy": "rowsNeeded"} in criteria
+    # No startRow/endRow when offset is 0
+    assert not any(c["searchBy"] in ("startRow", "endRow") for c in criteria)
 
 
 @pytest.mark.unit
-async def test_404_triggers_legacy_fallback(tm_client):
-    """ODP 404 falls back to the legacy XML API."""
-    odp_404 = _mock_response(404, text="Not found")
-    legacy_ok = _mock_response(200, text=MOCK_TM_ASSIGNMENT_LEGACY_XML)
+def test_build_search_criteria_all_filters():
+    """All filters land in the criteria list with correct field names."""
+    criteria = TmAssignmentClient.build_search_criteria(
+        {
+            "serial_number": "78787878",
+            "registration_number": "3500027",
+            "assignee_name": "New Owner LLC",
+            "assignor_name": "Old Owner Corp",
+            "reel_frame": "1234/0567",
+        },
+        offset=0,
+        limit=10,
+    )
 
-    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
-        m.side_effect = [odp_404, legacy_ok]
-        result = await tm_client.search_assignments(assignee_name="New Owner LLC")
-
-    assert result["backend"] == "legacy"
-    assert tm_client._backend == "legacy"
-    assert result["total"] == 2
-    assert m.call_count == 2
-
-    legacy_url = m.call_args_list[1][0][0]
-    assert legacy_url.startswith(f"{config.TM_ASSIGNMENT_BASE_URL}{LEGACY_SEARCH_PATH}")
-
-
-@pytest.mark.unit
-async def test_legacy_backend_cached_skips_odp(tm_client):
-    """Once legacy is cached, ODP is not probed again."""
-    tm_client._backend = "legacy"
-
-    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
-        m.return_value = _mock_response(200, text=MOCK_TM_ASSIGNMENT_LEGACY_XML)
-        result = await tm_client.search_assignments(assignor_name="Old Owner Corp")
-
-    assert m.call_count == 1
-    assert result["backend"] == "legacy"
-    called_url = m.call_args[0][0]
-    assert called_url.startswith(config.TM_ASSIGNMENT_BASE_URL)
+    search_bys = {c["searchBy"] for c in criteria}
+    assert {"serialNumber", "registrationNumber", "assigneeName",
+            "assignorName", "reelFrame", "rowsNeeded"} <= search_bys
 
 
 @pytest.mark.unit
-async def test_odp_non_404_error_does_not_fall_back(tm_client):
-    """A real ODP error (e.g. 403) is surfaced, not masked by fallback."""
-    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
-        m.return_value = _mock_response(403, text="Forbidden")
-        result = await tm_client.search_assignments(registration_number="3500027")
+def test_build_search_criteria_pagination():
+    """Offset converts to 1-based startRow/endRow criteria."""
+    criteria = TmAssignmentClient.build_search_criteria(
+        {"assignee_name": "X"}, offset=50, limit=25
+    )
 
-    assert result["error"] is True
-    assert result["status_code"] == 403
-    assert m.call_count == 1
+    assert {"property": "51", "searchBy": "startRow"} in criteria
+    assert {"property": "75", "searchBy": "endRow"} in criteria
+    assert {"property": "25", "searchBy": "rowsNeeded"} in criteria
+
+
+@pytest.mark.unit
+def test_build_search_criteria_caps_limit():
+    """Limits above the API maximum are capped."""
+    criteria = TmAssignmentClient.build_search_criteria(
+        {"assignee_name": "X"}, offset=0, limit=99999
+    )
+
+    assert {"property": str(MAX_ROWS_PER_REQUEST), "searchBy": "rowsNeeded"} in criteria
 
 
 # ============================================================================
-# Legacy XML Parsing Tests
+# Response Parsing Tests (pure function)
 # ============================================================================
 
 @pytest.mark.unit
-async def test_parse_legacy_xml(tm_client):
-    """Solr-style XML docs are converted into dicts with arrays."""
-    parsed = tm_client._parse_legacy_xml(MOCK_TM_ASSIGNMENT_LEGACY_XML)
+def test_parse_search_response():
+    """The list-wrapped envelope is unwrapped into results/total."""
+    parsed = TmAssignmentClient.parse_search_response(MOCK_TM_ASSIGNMENT_RESPONSE)
 
     assert parsed["total"] == 2
-    first = parsed["results"][0]
-    assert first["reelNo"] == "1234"
-    assert first["assignorName"] == ["Old Owner Corp"]
-    assert first["assigneeName"] == ["New Owner LLC"]
+    assert parsed["results"][0]["reelNumber"] == 1234
+    assert parsed["results"][0]["assignees"] == ["New Owner LLC"]
 
 
 @pytest.mark.unit
-async def test_parse_legacy_xml_invalid(tm_client):
-    """Invalid XML returns an error dict."""
-    parsed = tm_client._parse_legacy_xml("this is not xml <<<")
-    assert parsed["error"] is True
+def test_parse_search_response_empty():
+    """Empty data list parses to zero results."""
+    parsed = TmAssignmentClient.parse_search_response(MOCK_TM_ASSIGNMENT_EMPTY_RESPONSE)
 
-
-@pytest.mark.unit
-async def test_parse_legacy_xml_no_results(tm_client):
-    """XML without a result element returns empty results."""
-    parsed = tm_client._parse_legacy_xml("<response></response>")
     assert parsed == {"results": [], "total": 0}
 
 
+@pytest.mark.unit
+def test_parse_search_response_unexpected_shape():
+    """Garbage input degrades to empty results, not an exception."""
+    assert TmAssignmentClient.parse_search_response(None) == {"results": [], "total": 0}
+    assert TmAssignmentClient.parse_search_response([]) == {"results": [], "total": 0}
+    assert TmAssignmentClient.parse_search_response("nope") == {"results": [], "total": 0}
+
+
 # ============================================================================
-# ODP Query Building Tests
+# Search Flow Tests
 # ============================================================================
 
 @pytest.mark.unit
-async def test_odp_query_clauses(tm_client):
-    """All filters land in the Lucene q= parameter."""
-    with patch.object(tm_client, "_get", new_callable=AsyncMock) as m:
-        m.return_value = _mock_response(200, json_data={"count": 0, "results": []})
+async def test_search_assignments_success(tm_client):
+    """A successful search POSTs to the Assignment Center endpoint."""
+    with patch.object(tm_client, "_post", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=MOCK_TM_ASSIGNMENT_RESPONSE)
+        result = await tm_client.search_assignments(assignee_name="New Owner LLC")
+
+    assert result["backend"] == "assignment-center"
+    assert result["total"] == 2
+    assert result["results"][0]["reelNumber"] == 1234
+
+    called_url = m.call_args[0][0]
+    assert called_url == f"{config.TM_ASSIGNMENT_BASE_URL}{SEARCH_PATH}"
+    body = m.call_args[0][1]
+    assert {"property": "New Owner LLC", "searchBy": "assigneeName"} in body["searchCriteria"]
+
+
+@pytest.mark.unit
+async def test_search_assignments_combined_filters(tm_client):
+    """Multiple filters all appear in the request body (AND semantics)."""
+    with patch.object(tm_client, "_post", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=MOCK_TM_ASSIGNMENT_EMPTY_RESPONSE)
         await tm_client.search_assignments(
             serial_number="78787878",
             assignee_name="New Owner LLC",
         )
 
-    called_url = m.call_args[0][0]
-    assert "applicationNumberText%3A78787878" in called_url
-    assert "assigneeName" in called_url
+    body = m.call_args[0][1]
+    search_bys = {c["searchBy"] for c in body["searchCriteria"]}
+    assert "serialNumber" in search_bys
+    assert "assigneeName" in search_bys
+
+
+@pytest.mark.unit
+async def test_search_assignments_http_error(tm_client):
+    """HTTP errors surface as error dicts."""
+    with patch.object(tm_client, "_post", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(500, text="Server error")
+        result = await tm_client.search_assignments(assignee_name="X")
+
+    assert result["error"] is True
+    assert result["status_code"] == 500
+
+
+@pytest.mark.unit
+async def test_search_assignments_non_json(tm_client):
+    """A non-JSON 200 response surfaces as an error dict."""
+    with patch.object(tm_client, "_post", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=None, text="<html>")
+        result = await tm_client.search_assignments(assignee_name="X")
+
+    assert result["error"] is True
+
+
+@pytest.mark.unit
+async def test_search_assignments_reel_frame(tm_client):
+    """reel_frame is a supported search axis."""
+    with patch.object(tm_client, "_post", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=MOCK_TM_ASSIGNMENT_RESPONSE)
+        result = await tm_client.search_assignments(reel_frame="1234/0567")
+
+    assert result["total"] == 2
+    body = m.call_args[0][1]
+    assert {"property": "1234/0567", "searchBy": "reelFrame"} in body["searchCriteria"]

--- a/test/unit/test_tmsearch_client.py
+++ b/test/unit/test_tmsearch_client.py
@@ -1,0 +1,204 @@
+"""Unit tests for TmSearchClient (tmsearch.uspto.gov internal API)."""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from patent_mcp_server.uspto.tmsearch_client import TmSearchClient, SEARCH_PATH
+from patent_mcp_server.constants import TmSearchFields, TrademarkDefaults
+from patent_mcp_server.config import config
+
+from test.fixtures.tmsearch_responses import (
+    MOCK_TMSEARCH_RESPONSE,
+    MOCK_TMSEARCH_RESPONSE_INT_TOTAL,
+    MOCK_TMSEARCH_EMPTY_RESPONSE,
+)
+
+
+@pytest.fixture
+async def tmsearch_client():
+    """Create a TmSearchClient instance for testing."""
+    client = TmSearchClient()
+    yield client
+    await client.close()
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_client_initialization():
+    """Client sends browser-like headers and no API key."""
+    client = TmSearchClient()
+
+    assert client.headers["X-Requested-With"] == "XMLHttpRequest"
+    assert client.headers["Origin"] == config.TMSEARCH_BASE_URL
+    assert "X-API-KEY" not in client.headers
+    assert "USPTO-API-KEY" not in client.headers
+
+    await client.close()
+
+
+@pytest.mark.unit
+async def test_client_context_manager():
+    """Test client context manager protocol."""
+    async with TmSearchClient() as client:
+        assert client is not None
+
+
+# ============================================================================
+# build_search_body Tests (pure function, offline)
+# ============================================================================
+
+@pytest.mark.unit
+def test_build_body_mark_text():
+    body = TmSearchClient.build_search_body(mark_text="ACME")
+    must = body["query"]["bool"]["must"]
+    assert {"match": {TmSearchFields.WORDMARK: "ACME"}} in must
+
+
+@pytest.mark.unit
+def test_build_body_owner_name():
+    body = TmSearchClient.build_search_body(owner_name="Acme Corp")
+    must = body["query"]["bool"]["must"]
+    assert {"match": {TmSearchFields.OWNER: "Acme Corp"}} in must
+
+
+@pytest.mark.unit
+def test_build_body_serial_and_registration():
+    body = TmSearchClient.build_search_body(
+        serial_number="78787878", registration_number="3500027"
+    )
+    must = body["query"]["bool"]["must"]
+    assert {"term": {TmSearchFields.SERIAL_NUMBER: "78787878"}} in must
+    assert {"term": {TmSearchFields.REGISTRATION_NUMBER: "3500027"}} in must
+
+
+@pytest.mark.unit
+def test_build_body_raw_query():
+    body = TmSearchClient.build_search_body(query="wordmark:ACME*")
+    must = body["query"]["bool"]["must"]
+    assert must[0]["query_string"]["query"] == "wordmark:ACME*"
+
+
+@pytest.mark.unit
+def test_build_body_class_and_status_filters():
+    body = TmSearchClient.build_search_body(
+        mark_text="ACME", international_class="9", status_filter="live"
+    )
+    filters = body["query"]["bool"]["filter"]
+    assert {"term": {TmSearchFields.INTERNATIONAL_CLASS: "9"}} in filters
+    assert {"term": {TmSearchFields.ALIVE: True}} in filters
+
+    body_dead = TmSearchClient.build_search_body(
+        mark_text="ACME", status_filter="dead"
+    )
+    assert {"term": {TmSearchFields.ALIVE: False}} in body_dead["query"]["bool"]["filter"]
+
+
+@pytest.mark.unit
+def test_build_body_pagination():
+    body = TmSearchClient.build_search_body(mark_text="ACME", offset=50, limit=10)
+    assert body["from"] == 50
+    assert body["size"] == 10
+
+
+@pytest.mark.unit
+def test_build_body_limit_capped():
+    body = TmSearchClient.build_search_body(mark_text="ACME", limit=9999)
+    assert body["size"] == TrademarkDefaults.SEARCH_LIMIT_MAX
+
+
+@pytest.mark.unit
+def test_build_body_no_filters_is_match_all():
+    body = TmSearchClient.build_search_body()
+    assert body["query"]["bool"]["must"] == [{"match_all": {}}]
+
+
+# ============================================================================
+# parse_search_response Tests
+# ============================================================================
+
+@pytest.mark.unit
+def test_parse_response_es7_total():
+    parsed = TmSearchClient.parse_search_response(MOCK_TMSEARCH_RESPONSE)
+    assert parsed["total"] == 2
+    assert len(parsed["results"]) == 2
+    assert parsed["results"][0]["wordmark"] == "TESTMARK"
+
+
+@pytest.mark.unit
+def test_parse_response_int_total():
+    parsed = TmSearchClient.parse_search_response(MOCK_TMSEARCH_RESPONSE_INT_TOTAL)
+    assert parsed["total"] == 1
+    assert parsed["results"][0]["wordmark"] == "TESTMARK"
+
+
+@pytest.mark.unit
+def test_parse_response_empty():
+    parsed = TmSearchClient.parse_search_response(MOCK_TMSEARCH_EMPTY_RESPONSE)
+    assert parsed == {"results": [], "total": 0}
+
+
+@pytest.mark.unit
+def test_parse_response_malformed():
+    assert TmSearchClient.parse_search_response({}) == {"results": [], "total": 0}
+    assert TmSearchClient.parse_search_response({"hits": "garbage"}) == {
+        "results": [], "total": 0
+    }
+
+
+# ============================================================================
+# Request Wiring Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_search_posts_to_search_path(tmsearch_client):
+    """search() POSTs the built body to SEARCH_PATH and parses the result."""
+    with patch.object(tmsearch_client, "make_request", new_callable=AsyncMock) as m:
+        m.return_value = MOCK_TMSEARCH_RESPONSE
+        result = await tmsearch_client.search(mark_text="TESTMARK")
+
+    assert result["total"] == 2
+    body = m.call_args[0][0]
+    assert body["query"]["bool"]["must"] == [
+        {"match": {TmSearchFields.WORDMARK: "TESTMARK"}}
+    ]
+
+
+@pytest.mark.unit
+async def test_search_propagates_error(tmsearch_client):
+    """Error dicts from make_request pass through unparsed."""
+    with patch.object(tmsearch_client, "make_request", new_callable=AsyncMock) as m:
+        m.return_value = {"error": True, "message": "nope", "status_code": 500}
+        result = await tmsearch_client.search(mark_text="TESTMARK")
+
+    assert result["error"] is True
+
+
+@pytest.mark.unit
+async def test_get_by_serial(tmsearch_client):
+    """get_by_serial issues a single-term serial search."""
+    with patch.object(tmsearch_client, "make_request", new_callable=AsyncMock) as m:
+        m.return_value = MOCK_TMSEARCH_RESPONSE_INT_TOTAL
+        result = await tmsearch_client.get_by_serial("78787878")
+
+    body = m.call_args[0][0]
+    assert {"term": {TmSearchFields.SERIAL_NUMBER: "78787878"}} in body["query"]["bool"]["must"]
+    assert body["size"] == 1
+    assert result["total"] == 1
+
+
+@pytest.mark.unit
+async def test_make_request_url(tmsearch_client):
+    """make_request targets TMSEARCH_BASE_URL + SEARCH_PATH."""
+    captured = {}
+
+    async def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        raise RuntimeError("stop here")
+
+    with patch.object(tmsearch_client.client, "post", side_effect=fake_post):
+        result = await tmsearch_client.make_request({"query": {}})
+
+    assert captured["url"] == f"{config.TMSEARCH_BASE_URL}{SEARCH_PATH}"
+    assert result["error"] is True

--- a/test/unit/test_tmsearch_client.py
+++ b/test/unit/test_tmsearch_client.py
@@ -8,6 +8,7 @@ from patent_mcp_server.config import config
 
 from test.fixtures.tmsearch_responses import (
     MOCK_TMSEARCH_RESPONSE,
+    MOCK_TMSEARCH_ES7_RESPONSE,
     MOCK_TMSEARCH_RESPONSE_INT_TOTAL,
     MOCK_TMSEARCH_EMPTY_RESPONSE,
 )
@@ -30,7 +31,7 @@ async def test_client_initialization():
     """Client sends browser-like headers and no API key."""
     client = TmSearchClient()
 
-    assert client.headers["X-Requested-With"] == "XMLHttpRequest"
+    assert client.headers["Accept"] == "application/json, text/plain, */*"
     assert client.headers["Origin"] == config.TMSEARCH_BASE_URL
     assert "X-API-KEY" not in client.headers
     assert "USPTO-API-KEY" not in client.headers
@@ -86,13 +87,29 @@ def test_build_body_class_and_status_filters():
         mark_text="ACME", international_class="9", status_filter="live"
     )
     filters = body["query"]["bool"]["filter"]
-    assert {"term": {TmSearchFields.INTERNATIONAL_CLASS: "9"}} in filters
+    # Class numbers are zero-padded to 3 digits ("IC 009"-style index tokens)
+    assert {"term": {TmSearchFields.INTERNATIONAL_CLASS: "009"}} in filters
     assert {"term": {TmSearchFields.ALIVE: True}} in filters
 
     body_dead = TmSearchClient.build_search_body(
         mark_text="ACME", status_filter="dead"
     )
     assert {"term": {TmSearchFields.ALIVE: False}} in body_dead["query"]["bool"]["filter"]
+
+
+@pytest.mark.unit
+def test_build_body_goods_services():
+    body = TmSearchClient.build_search_body(goods_services="athletic footwear")
+    must = body["query"]["bool"]["must"]
+    assert {"match": {TmSearchFields.GOODS_AND_SERVICES: "athletic footwear"}} in must
+
+
+@pytest.mark.unit
+def test_build_body_class_not_padded_when_non_numeric():
+    """Pre-formatted class terms pass through unchanged."""
+    body = TmSearchClient.build_search_body(international_class="IC 009")
+    filters = body["query"]["bool"]["filter"]
+    assert {"term": {TmSearchFields.INTERNATIONAL_CLASS: "IC 009"}} in filters
 
 
 @pytest.mark.unit
@@ -119,10 +136,20 @@ def test_build_body_no_filters_is_match_all():
 # ============================================================================
 
 @pytest.mark.unit
-def test_parse_response_es7_total():
+def test_parse_response_live_shape():
+    """The live envelope (totalValue + source) parses correctly."""
     parsed = TmSearchClient.parse_search_response(MOCK_TMSEARCH_RESPONSE)
     assert parsed["total"] == 2
     assert len(parsed["results"]) == 2
+    assert parsed["results"][0]["wordmark"] == "TESTMARK"
+    assert parsed["results"][0]["id"] == "78787878"
+
+
+@pytest.mark.unit
+def test_parse_response_es7_fallback():
+    """A standard ES7 envelope (total object + _source) still parses."""
+    parsed = TmSearchClient.parse_search_response(MOCK_TMSEARCH_ES7_RESPONSE)
+    assert parsed["total"] == 1
     assert parsed["results"][0]["wordmark"] == "TESTMARK"
 
 
@@ -186,6 +213,49 @@ async def test_get_by_serial(tmsearch_client):
     assert {"term": {TmSearchFields.SERIAL_NUMBER: "78787878"}} in body["query"]["bool"]["must"]
     assert body["size"] == 1
     assert result["total"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("waf_status", [202, 403])
+async def test_waf_rejection_returns_actionable_error(tmsearch_client, waf_status):
+    """AWS WAF rejections (403 blocked / 202 challenge) get a hint."""
+    from unittest.mock import MagicMock
+    import httpx
+
+    waf_response = MagicMock(spec=httpx.Response)
+    waf_response.status_code = waf_status
+    waf_response.text = "<html>challenge</html>"
+
+    with patch.object(
+        tmsearch_client.client, "post", new_callable=AsyncMock
+    ) as m:
+        m.return_value = waf_response
+        result = await tmsearch_client.make_request({"query": {}})
+
+    assert result["error"] is True
+    assert "TMSEARCH_WAF_TOKEN" in result["hint"]
+
+
+@pytest.mark.unit
+async def test_non_json_200_is_waf_challenge(tmsearch_client):
+    """A 200 with non-JSON content is reported as a WAF challenge."""
+    from unittest.mock import MagicMock
+    import httpx
+
+    challenge = MagicMock(spec=httpx.Response)
+    challenge.status_code = 200
+    challenge.text = "<html>verify you are human</html>"
+    challenge.raise_for_status.return_value = None
+    challenge.json.side_effect = ValueError("not json")
+
+    with patch.object(
+        tmsearch_client.client, "post", new_callable=AsyncMock
+    ) as m:
+        m.return_value = challenge
+        result = await tmsearch_client.make_request({"query": {}})
+
+    assert result["error"] is True
+    assert result["error_code"] == "WAF_CHALLENGE"
 
 
 @pytest.mark.unit

--- a/test/unit/test_trademark_tools.py
+++ b/test/unit/test_trademark_tools.py
@@ -86,6 +86,33 @@ async def test_tsdr_get_trademark_image_invalid_serial():
     assert result["error_code"] == "VALIDATION_ERROR"
 
 
+@pytest.mark.unit
+async def test_tsdr_list_trademark_documents():
+    """Document metadata listing normalizes into the standard envelope."""
+    parsed = {
+        "results": [{"DocumentTypeCode": "OOA", "MailRoomDate": "2020-01-15-05:00"}],
+        "total": 1,
+    }
+    with patch.object(patents.tsdr_client, "list_case_documents",
+                      new_callable=AsyncMock) as m:
+        m.return_value = parsed
+        result = await patents.tsdr_list_trademark_documents("78787878")
+
+    assert result["success"] is True
+    assert result["source"] == "tsdr"
+    assert result["total"] == 1
+    assert result["results"][0]["DocumentTypeCode"] == "OOA"
+    m.assert_awaited_once_with("78787878")
+
+
+@pytest.mark.unit
+async def test_tsdr_list_trademark_documents_invalid_serial():
+    result = await patents.tsdr_list_trademark_documents("xyz")
+
+    assert result["error"] is True
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
 # ============================================================================
 # Trademark Search Tools
 # ============================================================================
@@ -113,6 +140,25 @@ async def test_tm_search_trademarks_normalizes_envelope():
     assert result["total"] == 42
     assert result["count"] == 1
     assert result["has_more"] is True
+
+
+@pytest.mark.unit
+async def test_tm_search_trademarks_goods_services_filter():
+    """goods_services alone satisfies the filter requirement and is passed on."""
+    with patch.object(patents.tmsearch_client, "search",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {"results": [], "total": 0}
+        await patents.tm_search_trademarks(goods_services="athletic footwear")
+
+    assert m.call_args.kwargs["goods_services"] == "athletic footwear"
+
+
+@pytest.mark.unit
+async def test_tm_search_trademarks_validates_registration_number():
+    result = await patents.tm_search_trademarks(registration_number="not-a-number")
+
+    assert result["error"] is True
+    assert result["error_code"] == "VALIDATION_ERROR"
 
 
 @pytest.mark.unit
@@ -165,13 +211,23 @@ async def test_tm_search_assignments_reports_backend():
         m.return_value = {
             "results": [{"reelNumber": "1234"}],
             "total": 1,
-            "backend": "odp",
+            "backend": "assignment-center",
         }
         result = await patents.tm_search_assignments(registration_number="3500027")
 
     assert result["success"] is True
     assert result["source"] == "tm_assignments"
-    assert result["metadata"]["backend"] == "odp"
+    assert result["metadata"]["backend"] == "assignment-center"
+
+
+@pytest.mark.unit
+async def test_tm_search_assignments_passes_reel_frame():
+    with patch.object(patents.tm_assignment_client, "search_assignments",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {"results": [], "total": 0, "backend": "assignment-center"}
+        await patents.tm_search_assignments(reel_frame="9006/0093")
+
+    assert m.call_args.kwargs["reel_frame"] == "9006/0093"
 
 
 # ============================================================================

--- a/test/unit/test_trademark_tools.py
+++ b/test/unit/test_trademark_tools.py
@@ -1,0 +1,240 @@
+"""Unit tests for the trademark MCP tools in patents.py."""
+import base64
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from patent_mcp_server import patents
+
+from test.fixtures.tsdr_responses import (
+    MOCK_TSDR_STATUS_RESPONSE,
+    MOCK_TSDR_PDF_CONTENT,
+)
+
+
+# ============================================================================
+# TSDR Tools
+# ============================================================================
+
+@pytest.mark.unit
+async def test_tsdr_get_trademark_status_by_serial():
+    with patch.object(patents.tsdr_client, "get_case_status",
+                      new_callable=AsyncMock) as m:
+        m.return_value = MOCK_TSDR_STATUS_RESPONSE
+        result = await patents.tsdr_get_trademark_status(serial_number="78787878")
+
+    assert result["success"] is True
+    assert result["source"] == "tsdr"
+    assert result["results"]["status"]["markElement"] == "TESTMARK"
+    m.assert_awaited_once_with(serial_number="78787878", registration_number=None)
+
+
+@pytest.mark.unit
+async def test_tsdr_get_trademark_status_cleans_serial():
+    """Serial numbers with separators are cleaned before the API call."""
+    with patch.object(patents.tsdr_client, "get_case_status",
+                      new_callable=AsyncMock) as m:
+        m.return_value = MOCK_TSDR_STATUS_RESPONSE
+        await patents.tsdr_get_trademark_status(serial_number="78/787,878")
+
+    m.assert_awaited_once_with(serial_number="78787878", registration_number=None)
+
+
+@pytest.mark.unit
+async def test_tsdr_get_trademark_status_invalid_serial():
+    """A serial number that isn't 8 digits is rejected before any request."""
+    result = await patents.tsdr_get_trademark_status(serial_number="123")
+
+    assert result["error"] is True
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.unit
+async def test_tsdr_get_trademark_status_by_registration():
+    with patch.object(patents.tsdr_client, "get_case_status",
+                      new_callable=AsyncMock) as m:
+        m.return_value = MOCK_TSDR_STATUS_RESPONSE
+        result = await patents.tsdr_get_trademark_status(registration_number="3500027")
+
+    assert result["success"] is True
+    m.assert_awaited_once_with(serial_number=None, registration_number="3500027")
+
+
+@pytest.mark.unit
+async def test_tsdr_download_trademark_documents():
+    """Binary responses pass through without envelope/truncation."""
+    payload = {
+        "success": True,
+        "filename": "tm-78787878-documents.pdf",
+        "content_type": "application/pdf",
+        "content": MOCK_TSDR_PDF_CONTENT,
+        "size_bytes": 60,
+    }
+    with patch.object(patents.tsdr_client, "download_case_documents",
+                      new_callable=AsyncMock) as m:
+        m.return_value = payload
+        result = await patents.tsdr_download_trademark_documents("78787878")
+
+    assert result == payload
+    assert base64.b64decode(result["content"]).startswith(b"%PDF")
+
+
+@pytest.mark.unit
+async def test_tsdr_get_trademark_image_invalid_serial():
+    result = await patents.tsdr_get_trademark_image("not-a-number")
+
+    assert result["error"] is True
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+# ============================================================================
+# Trademark Search Tools
+# ============================================================================
+
+@pytest.mark.unit
+async def test_tm_search_trademarks_requires_filter():
+    result = await patents.tm_search_trademarks()
+
+    assert result["error"] is True
+    assert result["error_code"] == "MISSING_FILTER"
+
+
+@pytest.mark.unit
+async def test_tm_search_trademarks_normalizes_envelope():
+    with patch.object(patents.tmsearch_client, "search",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {
+            "results": [{"id": "78787878", "wordmark": "TESTMARK"}],
+            "total": 42,
+        }
+        result = await patents.tm_search_trademarks(mark_text="TESTMARK", limit=25)
+
+    assert result["success"] is True
+    assert result["source"] == "tmsearch"
+    assert result["total"] == 42
+    assert result["count"] == 1
+    assert result["has_more"] is True
+
+
+@pytest.mark.unit
+async def test_tm_search_trademarks_propagates_error():
+    with patch.object(patents.tmsearch_client, "search",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {"error": True, "message": "down", "status_code": 503}
+        result = await patents.tm_search_trademarks(mark_text="TESTMARK")
+
+    assert result["error"] is True
+
+
+@pytest.mark.unit
+async def test_tm_get_trademark_not_found():
+    with patch.object(patents.tmsearch_client, "get_by_serial",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {"results": [], "total": 0}
+        result = await patents.tm_get_trademark("78787878")
+
+    assert result["error"] is True
+    assert result["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.unit
+async def test_tm_get_trademark_found():
+    with patch.object(patents.tmsearch_client, "get_by_serial",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {
+            "results": [{"id": "78787878", "wordmark": "TESTMARK"}],
+            "total": 1,
+        }
+        result = await patents.tm_get_trademark("78787878")
+
+    assert result["success"] is True
+    assert result["results"][0]["wordmark"] == "TESTMARK"
+
+
+@pytest.mark.unit
+async def test_tm_search_assignments_requires_filter():
+    result = await patents.tm_search_assignments()
+
+    assert result["error"] is True
+    assert result["error_code"] == "MISSING_FILTER"
+
+
+@pytest.mark.unit
+async def test_tm_search_assignments_reports_backend():
+    with patch.object(patents.tm_assignment_client, "search_assignments",
+                      new_callable=AsyncMock) as m:
+        m.return_value = {
+            "results": [{"reelNumber": "1234"}],
+            "total": 1,
+            "backend": "odp",
+        }
+        result = await patents.tm_search_assignments(registration_number="3500027")
+
+    assert result["success"] is True
+    assert result["source"] == "tm_assignments"
+    assert result["metadata"]["backend"] == "odp"
+
+
+# ============================================================================
+# Reference Lookup Tools
+# ============================================================================
+
+@pytest.mark.unit
+async def test_get_trademark_class_info_goods():
+    result = await patents.get_trademark_class_info("9")
+
+    assert result["class"] == "9"
+    assert result["type"] == "goods"
+    assert "software" in result["description"].lower()
+
+
+@pytest.mark.unit
+async def test_get_trademark_class_info_services():
+    result = await patents.get_trademark_class_info("42")
+
+    assert result["type"] == "services"
+
+
+@pytest.mark.unit
+async def test_get_trademark_class_info_accepts_leading_zero():
+    result = await patents.get_trademark_class_info("09")
+
+    assert result["class"] == "9"
+
+
+@pytest.mark.unit
+async def test_get_trademark_class_info_unknown():
+    result = await patents.get_trademark_class_info("99")
+
+    assert "error" in result
+
+
+@pytest.mark.unit
+async def test_get_trademark_status_code_known():
+    result = await patents.get_trademark_status_code("700")
+
+    assert result["code"] == "700"
+    assert result["description"] == "Registered"
+    assert result["stage"] == "registered"
+
+
+@pytest.mark.unit
+async def test_get_trademark_status_code_unknown():
+    result = await patents.get_trademark_status_code("12345")
+
+    assert "error" in result
+
+
+# ============================================================================
+# check_api_status Coverage
+# ============================================================================
+
+@pytest.mark.unit
+async def test_check_api_status_includes_trademark_sources():
+    result = await patents.check_api_status()
+
+    sources = result["sources"]
+    for key in ("tsdr", "tmsearch", "tm_assignments", "ttab"):
+        assert key in sources
+
+    assert sources["tmsearch"]["requires_auth"] is False
+    assert sources["ttab"]["status"] == "NOT_AVAILABLE_AS_API"

--- a/test/unit/test_tsdr_client.py
+++ b/test/unit/test_tsdr_client.py
@@ -4,13 +4,15 @@ import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 import httpx
 
-from patent_mcp_server.uspto.tsdr_client import TSDRClient
+from patent_mcp_server.uspto.tsdr_client import TSDRClient, DOCUMENT_LIST_NS
+from patent_mcp_server.constants import TrademarkDefaults
 from patent_mcp_server.config import config
 
 from test.fixtures.tsdr_responses import (
     MOCK_TSDR_STATUS_RESPONSE,
     MOCK_TSDR_PDF_BYTES,
     MOCK_TSDR_IMAGE_BYTES,
+    MOCK_TSDR_DOCUMENT_LIST_XML,
 )
 
 
@@ -69,16 +71,16 @@ async def test_client_context_manager():
 
 @pytest.mark.unit
 async def test_status_url_serial_number(tsdr_client):
-    """Serial number builds the sn{N}/info.json URL."""
+    """Serial number builds the sn{N}/info URL."""
     url = tsdr_client._status_url("78787878", None)
-    assert url == f"{config.TSDR_BASE_URL}/casestatus/sn78787878/info.json"
+    assert url == f"{config.TSDR_BASE_URL}/casestatus/sn78787878/info"
 
 
 @pytest.mark.unit
 async def test_status_url_registration_number(tsdr_client):
-    """Registration number builds the rn{N}/info.json URL."""
+    """Registration number builds the rn{N}/info URL."""
     url = tsdr_client._status_url(None, "3500027")
-    assert url == f"{config.TSDR_BASE_URL}/casestatus/rn3500027/info.json"
+    assert url == f"{config.TSDR_BASE_URL}/casestatus/rn3500027/info"
 
 
 @pytest.mark.unit
@@ -106,7 +108,7 @@ async def test_get_case_status_returns_json(tsdr_client):
 
     assert result == MOCK_TSDR_STATUS_RESPONSE
     called_url = m.call_args[0][0]
-    assert called_url.endswith("/casestatus/sn78787878/info.json")
+    assert called_url.endswith("/casestatus/sn78787878/info")
 
 
 @pytest.mark.unit
@@ -128,6 +130,87 @@ async def test_get_case_status_non_json_response(tsdr_client):
         result = await tsdr_client.get_case_status(serial_number="78787878")
 
     assert result["error"] is True
+
+
+@pytest.mark.unit
+async def test_get_case_status_odp_key_hint(tsdr_client):
+    """The gateway's ODP-key 404 signature gets an actionable hint."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            404, content=b" BACKEND RESPONSE STATUS: 404"
+        )
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result["error"] is True
+    assert "TSDR" in result["hint"]
+    assert "api-manager" in result["hint"]
+
+
+@pytest.mark.unit
+async def test_get_case_status_401_hint(tsdr_client):
+    """A 401 (missing key) gets a key-registration hint."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(401, content=b"Unauthorized")
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result["error"] is True
+    assert "api-manager" in result["hint"]
+
+
+@pytest.mark.unit
+async def test_json_requests_send_accept_header(tsdr_client):
+    """JSON requests negotiate content type via the Accept header."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=MOCK_TSDR_STATUS_RESPONSE)
+        await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert m.call_args.kwargs.get("headers") == {"Accept": "application/json"}
+
+
+@pytest.mark.unit
+async def test_list_case_documents(tsdr_client):
+    """Document metadata list hits /casedocs/sn{N}/info and parses the XML."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            200, content=MOCK_TSDR_DOCUMENT_LIST_XML.encode("utf-8")
+        )
+        result = await tsdr_client.list_case_documents("78787878")
+
+    assert result["total"] == 2
+    first = result["results"][0]
+    assert first["DocumentTypeCode"] == "OOA"
+    assert first["MailRoomDate"] == "2020-01-15-05:00"
+    assert first["PageMediaTypeList"] == ["image/tiff"]
+    called_url = m.call_args[0][0]
+    assert called_url.endswith("/casedocs/sn78787878/info")
+
+
+@pytest.mark.unit
+async def test_list_case_documents_does_not_request_json(tsdr_client):
+    """The casedocs endpoint 406es on Accept: application/json — the
+    request must NOT negotiate JSON (verified live 2026-06-10)."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            200, content=MOCK_TSDR_DOCUMENT_LIST_XML.encode("utf-8")
+        )
+        await tsdr_client.list_case_documents("78787878")
+
+    assert m.call_args.kwargs.get("headers") is None
+
+
+@pytest.mark.unit
+def test_parse_document_list_xml_invalid():
+    """Invalid XML returns an error dict."""
+    result = TSDRClient._parse_document_list_xml("not xml <<<")
+    assert result["error"] is True
+
+
+@pytest.mark.unit
+def test_parse_document_list_xml_empty():
+    """An empty DocumentList parses to zero results."""
+    xml = f'<?xml version="1.0"?><DocumentList xmlns="{DOCUMENT_LIST_NS}"/>'
+    result = TSDRClient._parse_document_list_xml(xml)
+    assert result == {"results": [], "total": 0}
 
 
 # ============================================================================
@@ -189,6 +272,21 @@ async def test_get_mark_image_returns_base64(tsdr_client):
 
     called_url = m.call_args[0][0]
     assert called_url.endswith("/rawImage/78787878")
+
+
+@pytest.mark.unit
+async def test_binary_request_size_guard(tsdr_client):
+    """Oversized bundles are rejected with filter guidance, not base64'd."""
+    huge = b"%PDF" + b"\x00" * (TrademarkDefaults.MAX_BINARY_BYTES + 1)
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            200, content=huge, headers={"content-type": "application/pdf"}
+        )
+        result = await tsdr_client.download_case_documents("78787878")
+
+    assert result["error"] is True
+    assert result["error_code"] == "RESPONSE_TOO_LARGE"
+    assert "tsdr_list_trademark_documents" in result["message"]
 
 
 @pytest.mark.unit

--- a/test/unit/test_tsdr_client.py
+++ b/test/unit/test_tsdr_client.py
@@ -1,0 +1,234 @@
+"""Unit tests for TSDRClient (tsdrapi.uspto.gov)."""
+import base64
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from patent_mcp_server.uspto.tsdr_client import TSDRClient
+from patent_mcp_server.config import config
+
+from test.fixtures.tsdr_responses import (
+    MOCK_TSDR_STATUS_RESPONSE,
+    MOCK_TSDR_PDF_BYTES,
+    MOCK_TSDR_IMAGE_BYTES,
+)
+
+
+@pytest.fixture
+async def tsdr_client():
+    """Create a TSDRClient instance for testing."""
+    client = TSDRClient()
+    yield client
+    await client.close()
+
+
+def _mock_response(status_code=200, json_data=None, content=b"", headers=None):
+    """Build a MagicMock httpx.Response."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.content = content
+    response.text = content.decode("utf-8", errors="replace") if content else ""
+    if json_data is not None:
+        response.json.return_value = json_data
+        import json as _json
+        response.text = _json.dumps(json_data)
+    else:
+        response.json.side_effect = ValueError("no json")
+    return response
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_client_initialization():
+    """Client sends the USPTO-API-KEY header (not X-API-KEY)."""
+    client = TSDRClient()
+
+    assert "User-Agent" in client.headers
+    assert "USPTO-API-KEY" in client.headers
+    assert "X-API-KEY" not in client.headers
+    assert client.client is not None
+
+    await client.close()
+
+
+@pytest.mark.unit
+async def test_client_context_manager():
+    """Test client context manager protocol."""
+    async with TSDRClient() as client:
+        assert client is not None
+        assert client.client is not None
+
+
+# ============================================================================
+# URL Building Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_status_url_serial_number(tsdr_client):
+    """Serial number builds the sn{N}/info.json URL."""
+    url = tsdr_client._status_url("78787878", None)
+    assert url == f"{config.TSDR_BASE_URL}/casestatus/sn78787878/info.json"
+
+
+@pytest.mark.unit
+async def test_status_url_registration_number(tsdr_client):
+    """Registration number builds the rn{N}/info.json URL."""
+    url = tsdr_client._status_url(None, "3500027")
+    assert url == f"{config.TSDR_BASE_URL}/casestatus/rn3500027/info.json"
+
+
+@pytest.mark.unit
+async def test_status_url_requires_exactly_one_identifier(tsdr_client):
+    """Both or neither identifier returns a validation error."""
+    neither = tsdr_client._status_url(None, None)
+    both = tsdr_client._status_url("78787878", "3500027")
+
+    for result in (neither, both):
+        assert isinstance(result, dict)
+        assert result["error"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+
+# ============================================================================
+# JSON Request Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_get_case_status_returns_json(tsdr_client):
+    """Successful status request returns parsed JSON."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, json_data=MOCK_TSDR_STATUS_RESPONSE)
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result == MOCK_TSDR_STATUS_RESPONSE
+    called_url = m.call_args[0][0]
+    assert called_url.endswith("/casestatus/sn78787878/info.json")
+
+
+@pytest.mark.unit
+async def test_get_case_status_http_error(tsdr_client):
+    """Non-200 returns an ApiError dict with status code."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(401, content=b"Unauthorized")
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result["error"] is True
+    assert result["status_code"] == 401
+
+
+@pytest.mark.unit
+async def test_get_case_status_non_json_response(tsdr_client):
+    """200 with non-JSON body returns an error dict, not an exception."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(200, content=b"<html>not json</html>")
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result["error"] is True
+
+
+# ============================================================================
+# Binary Request Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_download_case_documents_returns_base64(tsdr_client):
+    """PDF bundle is returned base64-encoded with the PPUBS envelope shape."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            200, content=MOCK_TSDR_PDF_BYTES,
+            headers={"content-type": "application/pdf"}
+        )
+        result = await tsdr_client.download_case_documents("78787878")
+
+    assert result["success"] is True
+    assert result["filename"] == "tm-78787878-documents.pdf"
+    assert result["content_type"] == "application/pdf"
+    assert result["size_bytes"] == len(MOCK_TSDR_PDF_BYTES)
+    assert base64.b64decode(result["content"]) == MOCK_TSDR_PDF_BYTES
+
+    called_url = m.call_args[0][0]
+    assert "/casedocs/bundle.pdf?sn=78787878" in called_url
+
+
+@pytest.mark.unit
+async def test_download_case_documents_with_filters(tsdr_client):
+    """Document type and date filters appear in the query string."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            200, content=MOCK_TSDR_PDF_BYTES,
+            headers={"content-type": "application/pdf"}
+        )
+        await tsdr_client.download_case_documents(
+            "78787878", document_type="OOA",
+            date_from="2020-01-01", date_to="2020-12-31"
+        )
+
+    called_url = m.call_args[0][0]
+    assert "type=OOA" in called_url
+    assert "fromDate=2020-01-01" in called_url
+    assert "toDate=2020-12-31" in called_url
+
+
+@pytest.mark.unit
+async def test_get_mark_image_returns_base64(tsdr_client):
+    """Mark image is returned base64-encoded with content type passthrough."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(
+            200, content=MOCK_TSDR_IMAGE_BYTES,
+            headers={"content-type": "image/png"}
+        )
+        result = await tsdr_client.get_mark_image("78787878")
+
+    assert result["success"] is True
+    assert result["content_type"] == "image/png"
+    assert base64.b64decode(result["content"]) == MOCK_TSDR_IMAGE_BYTES
+
+    called_url = m.call_args[0][0]
+    assert called_url.endswith("/rawImage/78787878")
+
+
+@pytest.mark.unit
+async def test_binary_request_http_error(tsdr_client):
+    """Binary request error returns an ApiError dict."""
+    with patch.object(tsdr_client, "_get", new_callable=AsyncMock) as m:
+        m.return_value = _mock_response(404, content=b"Not found")
+        result = await tsdr_client.get_mark_image("00000000")
+
+    assert result["error"] is True
+    assert result["status_code"] == 404
+
+
+# ============================================================================
+# Rate Limit (429) Handling Tests
+# ============================================================================
+
+@pytest.mark.unit
+async def test_429_retries_after_wait(tsdr_client):
+    """A 429 response sleeps per Retry-After and retries once."""
+    rate_limited = _mock_response(429, content=b"Too many requests",
+                                  headers={"Retry-After": "0"})
+    ok = _mock_response(200, json_data=MOCK_TSDR_STATUS_RESPONSE)
+
+    with patch.object(tsdr_client.client, "get", new_callable=AsyncMock) as m, \
+         patch("patent_mcp_server.uspto.tsdr_client.asyncio.sleep",
+               new_callable=AsyncMock) as sleep_mock:
+        m.side_effect = [rate_limited, ok]
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result == MOCK_TSDR_STATUS_RESPONSE
+    assert m.call_count == 2
+    sleep_mock.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_unexpected_exception_returns_error_dict(tsdr_client):
+    """Unexpected exceptions are wrapped into ApiError dicts."""
+    with patch.object(tsdr_client.client, "get", new_callable=AsyncMock) as m:
+        m.side_effect = RuntimeError("boom")
+        result = await tsdr_client.get_case_status(serial_number="78787878")
+
+    assert result["error"] is True

--- a/test/unit/test_validation.py
+++ b/test/unit/test_validation.py
@@ -1,7 +1,10 @@
 """Unit tests for validation functions."""
 import pytest
 
-from patent_mcp_server.util.validation import validate_patent_number, validate_app_number
+from patent_mcp_server.util.validation import (
+    validate_patent_number, validate_app_number,
+    validate_serial_number, validate_registration_number
+)
 
 
 # ============================================================================
@@ -275,3 +278,62 @@ def test_validate_app_number_typical_lengths():
 
     # Series code + number (14/412,875)
     assert validate_app_number("14/412875") == "14412875"
+
+
+# ============================================================================
+# Trademark Serial Number Validation Tests
+# ============================================================================
+
+@pytest.mark.unit
+def test_validate_serial_number_valid():
+    """Test trademark serial number validation with valid inputs."""
+    assert validate_serial_number("78787878") == "78787878"
+
+    # Separators are stripped
+    assert validate_serial_number("78/787,878") == "78787878"
+    assert validate_serial_number(" 78787878 ") == "78787878"
+
+
+@pytest.mark.unit
+def test_validate_serial_number_wrong_length():
+    """Trademark serial numbers must be exactly 8 digits."""
+    with pytest.raises(ValueError, match="exactly 8 digits"):
+        validate_serial_number("1234567")
+
+    with pytest.raises(ValueError, match="exactly 8 digits"):
+        validate_serial_number("123456789")
+
+
+@pytest.mark.unit
+def test_validate_serial_number_no_digits():
+    """Serial number with no digits is rejected."""
+    with pytest.raises(ValueError):
+        validate_serial_number("abcdefgh")
+
+
+# ============================================================================
+# Trademark Registration Number Validation Tests
+# ============================================================================
+
+@pytest.mark.unit
+def test_validate_registration_number_valid():
+    """Test trademark registration number validation with valid inputs."""
+    assert validate_registration_number("3500027") == "3500027"
+
+    # Separators are stripped, short numbers allowed
+    assert validate_registration_number("3,500,027") == "3500027"
+    assert validate_registration_number("123") == "123"
+
+
+@pytest.mark.unit
+def test_validate_registration_number_too_long():
+    """Registration numbers over 8 digits are rejected."""
+    with pytest.raises(ValueError, match="at most 8 digits"):
+        validate_registration_number("123456789")
+
+
+@pytest.mark.unit
+def test_validate_registration_number_no_digits():
+    """Registration number with no digits is rejected."""
+    with pytest.raises(ValueError):
+        validate_registration_number("abc")

--- a/uv.lock
+++ b/uv.lock
@@ -805,7 +805,7 @@ wheels = [
 
 [[package]]
 name = "patent-mcp-server"
-version = "0.9.5"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "h2" },


### PR DESCRIPTION
## Summary

Adds full USPTO **trademark** support to the patent MCP server — 9 new trademark tools across three new API clients, bringing the server to **61 registered tools (36 active)**. All trademark backends are **verified end-to-end against the live USPTO services** (7/7 integration tests pass as of 2026-06-10).

### New capabilities

**TSDR — official status & documents API (`tsdr_*`)**
- `tsdr_get_trademark_status` — authoritative live status by serial or registration number
- `tsdr_list_trademark_documents` — file-wrapper document metadata (XML-only endpoint, parsed to JSON; not subject to the PDF rate limit)
- `tsdr_download_trademark_documents` — filtered PDF bundles (4/min limit; >4 MB rejected with filter guidance since full wrappers can exceed 10 MB)
- `tsdr_get_trademark_image` — mark drawing as base64
- Requires a **TSDR-specific API key** — the ODP key passes the gateway but 404s on the backend; the client detects that exact signature and returns instructions for account.uspto.gov/profile/api-manager

**Trademark search — TESS replacement internal API (`tm_search_trademarks`, `tm_get_trademark`)**
- Full-text search by mark text, owner, goods/services, Nice class, live/dead status (clearance/knockout searches)
- Same unofficial-API posture as PPUBS; contract verified live (`POST /prod-stage-v1-0-0/tmsearch`, non-standard ES envelope)
- Class filters auto-zero-pad ("25" → "025" — unpadded silently matches nothing)
- AWS WAF rejections handled with actionable errors + optional `TMSEARCH_WAF_TOKEN` escape hatch

**Trademark assignments — Assignment Center (`tm_search_assignments`)**
- Ownership-transfer records 1955–present via assignmentcenter.uspto.gov (**no API key**)
- Search by serial, registration, assignee, assignor, or reel/frame; filters AND-combine
- Replaces the legacy assignment-api.uspto.gov XML API decommissioned with the Developer Hub on June 5, 2026

**Reference data & workflows**
- `get_trademark_class_info` / `get_trademark_status_code` tools; `trademarks://classes` and `trademarks://status-codes` MCP resources (all 45 Nice classes)
- 3 new prompts: `trademark_clearance_search`, `trademark_portfolio_review`, `trademark_status_monitoring`
- Patent prompts rewritten to stop referencing decommissioned tools; fixed a latent `TypeError` in `ppubs_download_patent_pdf`

### Verification

The original trademark commit was written without network access; live verification then found all three backend contracts broken (wrong tmsearch path/envelope/field names; both assignment backends dead; TSDR key confusion). The second commit fixes every contract against production:

```
uv run pytest                                     # 359 passed
uv run pytest -m integration -k trademark         # 7 passed (4 keyless + 3 with TSDR key)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)