### PR TITLE
Add streamable-http transport and fix session concurrency (v1.1.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        # Pinned to the exact release: this action publishes no floating v9
+        # major tag. Dependabot keeps it current.
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+# A new push supersedes whatever is still running for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The range pyproject.toml declares support for.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      # Integration tests are deselected by pytest.ini, so this needs no
+      # network access and no USPTO API keys.
+      - name: Run unit tests
+        run: uv run pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ uv run pytest
 
 If tests fail, fix them before committing. Do not skip or delete failing tests unless the functionality has been intentionally removed.
 
+`.github/workflows/tests.yml` runs the same suite on every push to `main` and every pull request, across Python 3.10–3.13. Integration tests stay deselected there, so CI needs no API keys and no network access to USPTO.
+
 ### Release Workflow
 
 When publishing a new version:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,11 @@ This file provides guidance for Claude Code and other AI assistants working on t
 
 This is a Model Context Protocol (MCP) server that provides access to USPTO patent and trademark data through multiple APIs. The server is built with FastMCP and uses async/await patterns throughout. Published to PyPI as `patent-mcp-server`.
 
-**Current state (v1.0.0):** 61 registered tools, 36 active, 25 unavailable due to API shutdowns:
+**Transports:** `stdio` by default (Claude Desktop/Code), or `--transport streamable-http` for remote hosting. HTTP mode is stateless by default so it scales across workers without session affinity. Two things to know before touching the server lifecycle:
+- **Do not move client shutdown into a FastMCP `lifespan`.** In stateless HTTP mode the low-level server is entered once *per request*, so a lifespan would close the nine httpx clients after the first tool call. Shutdown lives in `serve()` in `patents.py`, inside the same event loop the clients were opened on.
+- **`PpubsClient` holds an upstream USPTO session** (cookie jar, `case_id`, access token) shared by all concurrent calls. Session setup is serialized by `_session_lock`; the access token is passed per request rather than stored on the shared client's default headers. Keep it that way — see the concurrency tests in `test/unit/test_ppubs_client.py`.
+
+**Current state (v1.1.0):** 61 registered tools, 36 active, 25 unavailable due to API shutdowns:
 - **Active:** PPUBS (5), ODP (12), PTAB (7), TSDR (4), Trademark search/assignments (3), Utility (5)
 - **Unavailable:** PatentsView (14, shut down March 2026), Office Actions (4, decommissioned early 2026), Enriched Citations (3, decommissioned early 2026), Litigation (4, not offered on ODP — issue #16)
 
@@ -23,7 +27,7 @@ This is a Model Context Protocol (MCP) server that provides access to USPTO pate
 
 ```bash
 uv run pytest
-# Expected: ~359 passed, ~54 deselected (integration tests skipped by default)
+# Expected: ~378 passed, ~54 deselected (integration tests skipped by default)
 ```
 
 If tests fail, fix them before committing. Do not skip or delete failing tests unless the functionality has been intentionally removed.

--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ uv run pytest --cov=patent_mcp_server
 
 Test results are stored in `/test/test_results/`.
 
+The unit suite also runs in CI on every push to `main` and every pull request, across Python 3.10–3.13 (`.github/workflows/tests.yml`). Integration tests stay deselected there, so CI needs no API keys.
+
 ### Development
 
 To install development dependencies:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This server provides **61 tools** across 9 USPTO data sources (36 active, 25 una
 8. **Trademark Status & Documents** - Authoritative live status, prosecution documents, and mark images via TSDR
 9. **Trademark Assignments** - Recorded ownership transfer records from 1955 to present (no API key needed)
 
+It runs locally over stdio for Claude Desktop and Claude Code, or over HTTP as a shared, stateless service — see [Remote hosting over HTTP](#remote-hosting-over-http).
+
 > **Note on unavailable APIs:** The PatentsView API (search.patentsview.org) was shut down on March 20, 2026, with its data migrated to ODP bulk datasets. The Office Action and Enriched Citation APIs (developer.uspto.gov) were decommissioned in early 2026. The Patent Litigation API is not offered on the USPTO Open Data Portal; litigation data is available as a bulk download. All 25 affected tools remain registered and return helpful workaround guidance pointing to alternative tools.
 
 ## API Sources
@@ -123,6 +125,14 @@ TMSEARCH_WAF_TOKEN=...           # Optional - only if trademark search hits the 
 # Logging
 LOG_LEVEL=INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
+# MCP Transport (see "Remote hosting over HTTP" below)
+MCP_TRANSPORT=stdio    # stdio (default) or streamable-http
+MCP_HOST=127.0.0.1     # Bind address when serving over HTTP
+MCP_PORT=8000          # Port when serving over HTTP
+MCP_PATH=/mcp          # URL path of the MCP endpoint
+MCP_STATELESS=true     # Keep no per-client state between HTTP requests
+MCP_JSON_RESPONSE=false # Reply with plain JSON instead of an SSE stream
+
 # HTTP Settings
 REQUEST_TIMEOUT=30.0  # Request timeout in seconds
 MAX_RETRIES=3         # Maximum number of retry attempts
@@ -177,6 +187,48 @@ claude mcp add-json patents '{"command": "uv", "args": ["--directory", "/path/to
 ```
 
 If you're already running Claude Code, you'll have to /exit and restart. Then /mcp to verify that it's configured.
+
+## Remote hosting over HTTP
+
+The server speaks stdio by default, which is what the Claude Desktop and
+Claude Code configurations above launch. It can instead serve the MCP
+endpoint over HTTP, so one deployment can back a whole team rather than
+every person running their own copy with their own API keys:
+
+```shell
+patent-mcp-server --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+The endpoint is then at `http://<host>:8000/mcp`. Point an MCP client at
+that URL — in Claude Code:
+
+```shell
+claude mcp add --transport http patents http://your-host:8000/mcp
+```
+
+**This endpoint has no authentication of its own, and it holds your USPTO
+and TSDR API keys.** Anyone who can reach it can spend your USPTO rate
+limits. Bind to `127.0.0.1` (the default) and put an authenticating reverse
+proxy in front of it, or otherwise restrict network access. The server logs
+a warning at startup when it is bound to anything other than loopback.
+
+Requests are stateless by default: the server keeps no per-client state
+between them, so it can run behind a load balancer with several replicas
+and no session affinity. Each worker holds its own upstream USPTO Public
+Search session, which it establishes on demand and refreshes when it
+expires.
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--transport` | `stdio` | `stdio` or `streamable-http` |
+| `--host` | `127.0.0.1` | Bind address for HTTP |
+| `--port` | `8000` | Port for HTTP |
+| `--path` | `/mcp` | URL path of the MCP endpoint |
+| `--stateful` / `--no-stateful` | off | Keep per-client session state; needs session affinity to scale |
+| `--json-response` / `--no-json-response` | off | Reply with plain JSON instead of an SSE stream |
+
+Each flag has a matching environment variable (see Configuration above);
+the command line wins where both are set.
 
 ## Available Tools
 
@@ -362,7 +414,15 @@ Issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribut
 
 ## Version History
 
-### v1.0.0 (Current)
+### v1.1.0 (Current)
+- **Remote hosting over HTTP**: new `--transport streamable-http` mode serves the MCP endpoint over the network, so one deployment can back a whole team instead of every user running a local copy. `stdio` remains the default, so existing Claude Desktop and Claude Code configurations are unchanged. New flags `--host`, `--port`, `--path`, `--stateful`, `--json-response`, each with a matching `MCP_*` environment variable. See "Remote hosting over HTTP" for the security caveat — the endpoint holds your API keys and does not authenticate callers
+- **Stateless by default**: HTTP requests carry no per-client state, so the server can run behind a load balancer with several replicas and no session affinity
+- **Fixed a session race in the Public Search client** (affects stdio users too): concurrent tool calls each reset the shared cookie jar and raced to swap the access token, so requests already in flight could be signed with a half-replaced session. Session setup is now serialized, a 403 refresh is skipped when another call has already replaced the token, and the token travels per request instead of living on the shared client's default headers
+- **Fixed shutdown**: closing the nine HTTP clients no longer happens in an `atexit` hook that spun up a fresh event loop; it now runs in the loop the clients were opened on. Deliberately not a FastMCP lifespan — in stateless HTTP mode that runs once per request, which would close the clients after the first tool call
+- Raised the MCP SDK floor to `>=1.27` (was `>=1.3.0`, which allowed installs to resolve an SDK without streamable HTTP)
+- Added MCP protocol-layer tests: the suite previously called tool functions directly and never exercised schema generation, resource/prompt registration, or serialization. 19 new tests (378 total, up from 359)
+
+### v1.0.0
 - **Trademark support**: 9 new trademark tools across three new clients, all verified against the live USPTO services on 2026-06-10
   - TSDR (`tsdr_get_trademark_status`, `tsdr_list_trademark_documents`, `tsdr_download_trademark_documents`, `tsdr_get_trademark_image`) — official trademark status/document API. Requires a TSDR-specific key (the ODP key does not work); error responses detect the wrong-key signature and explain how to get the right one. Document bundles above 4 MB are rejected with filter guidance (full wrappers can exceed 10 MB)
   - Trademark search (`tm_search_trademarks`, `tm_get_trademark`) — full-text search by mark text, owner, goods/services, and Nice class via the internal Elasticsearch API behind tmsearch.uspto.gov (no official REST API exists). Verified live; handles AWS WAF rejections with `TMSEARCH_WAF_TOKEN` support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "patent-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 description = "Model Context Protocol server for USPTO patent and trademark data"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "h2>=4.2.0",
     "httpx>=0.28.1",
-    "mcp[cli]>=1.3.0",
+    "mcp[cli]>=1.27",           # streamable-http transport with stateless_http
     "pydantic>=2.0.0",
     "python-dotenv>=1.2.2",      # CVE-2026-28684 fix
     "python-multipart>=0.0.27",  # CVE-2026-24486, CVE-2026-40347, CVE-2026-42561 fix

--- a/src/patent_mcp_server/config.py
+++ b/src/patent_mcp_server/config.py
@@ -13,6 +13,13 @@ import logging
 # Load environment variables from .env file
 load_dotenv()
 
+# Transports this server can speak. The MCP "sse" transport is deliberately
+# omitted: it is deprecated in favour of streamable-http.
+VALID_TRANSPORTS = frozenset({"stdio", "streamable-http"})
+
+# Hosts that keep an HTTP deployment on the local machine only.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
 
 class Config:
     """Centralized configuration class."""
@@ -49,8 +56,25 @@ class Config:
     # Logging
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
 
+    # MCP Transport
+    # "stdio" (default) keeps the local Claude Desktop/Code integration
+    # unchanged. "streamable-http" serves the MCP endpoint over HTTP for
+    # remote/shared deployments — see the hosting section of README.md, and
+    # note that an HTTP endpoint exposes the operator's USPTO API keys to
+    # anyone who can reach it, so it must sit behind authentication.
+    MCP_TRANSPORT: str = os.getenv("MCP_TRANSPORT", "stdio")
+    MCP_HOST: str = os.getenv("MCP_HOST", "127.0.0.1")
+    MCP_PORT: int = int(os.getenv("MCP_PORT", "8000"))
+    MCP_PATH: str = os.getenv("MCP_PATH", "/mcp")
+    # Stateless mode holds no per-client session state between requests, so
+    # the server can run behind a load balancer with several workers and no
+    # session affinity. Each worker keeps its own upstream USPTO session.
+    MCP_STATELESS: bool = os.getenv("MCP_STATELESS", "true").lower() == "true"
+    # Return a single JSON response per request instead of an SSE stream.
+    MCP_JSON_RESPONSE: bool = os.getenv("MCP_JSON_RESPONSE", "false").lower() == "true"
+
     # HTTP Settings
-    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/1.0.0")
+    USER_AGENT: str = os.getenv("USER_AGENT", "patent-mcp-server/1.1.0")
     REQUEST_TIMEOUT: float = float(os.getenv("REQUEST_TIMEOUT", "30.0"))
 
     # Rate Limiting & Retry
@@ -114,9 +138,24 @@ class Config:
 
         # PatentsView API was shut down March 20, 2026 - no longer warn about missing key
 
+        if cls.MCP_TRANSPORT not in VALID_TRANSPORTS:
+            logger.warning(
+                f"MCP_TRANSPORT={cls.MCP_TRANSPORT!r} is not recognized. "
+                f"Valid values are {sorted(VALID_TRANSPORTS)}. Falling back to 'stdio'."
+            )
+
+        if cls.MCP_TRANSPORT == "streamable-http" and cls.MCP_HOST not in LOOPBACK_HOSTS:
+            logger.warning(
+                f"Serving MCP over HTTP on {cls.MCP_HOST}:{cls.MCP_PORT}, which is "
+                "reachable beyond this machine. This server holds your USPTO and "
+                "TSDR API keys and performs no authentication of its own — put it "
+                "behind an authenticating reverse proxy or restrict network access."
+            )
+
         logger.info(f"Configuration loaded: LOG_LEVEL={cls.LOG_LEVEL}, "
                    f"TIMEOUT={cls.REQUEST_TIMEOUT}s, "
-                   f"CACHING={'enabled' if cls.ENABLE_CACHING else 'disabled'}")
+                   f"CACHING={'enabled' if cls.ENABLE_CACHING else 'disabled'}, "
+                   f"TRANSPORT={cls.MCP_TRANSPORT}")
 
 
 # Create singleton instance

--- a/src/patent_mcp_server/patents.py
+++ b/src/patent_mcp_server/patents.py
@@ -13,20 +13,25 @@ with multiple USPTO patent and trademark data APIs:
 7. PatentsView API - UNAVAILABLE (shut down March 2026; data migrated to ODP bulk datasets)
 8. Office Action APIs - UNAVAILABLE (decommissioned early 2026, pending ODP migration)
 
-The server uses stdio transport for Claude Code/Cursor integration.
+The server speaks stdio by default, for Claude Code/Cursor integration, and
+can also serve the MCP endpoint over streamable HTTP for remote deployments
+(``--transport streamable-http``). The HTTP mode is stateless: no per-client
+state is kept between requests, so it can run behind a load balancer with
+several workers and no session affinity.
 
-Version: 1.0.0
+Version: 1.1.0
 """
-import atexit
+import argparse
 import json
 import logging
 import sys
 from typing import Any, Dict, List, Optional, Union
 
+import anyio
 from mcp.server.fastmcp import FastMCP
 from pydantic import ValidationError
 
-from patent_mcp_server.config import config
+from patent_mcp_server.config import config, LOOPBACK_HOSTS, VALID_TRANSPORTS
 from patent_mcp_server.constants import (
     Sources, Fields, Defaults, PatentsViewEndpoints
 )
@@ -72,6 +77,12 @@ mcp = FastMCP(
         "get_trademark_status_code. Use check_api_status to see which "
         "sources are configured and available."
     ),
+    # Transport defaults; main() overrides these from command-line flags.
+    host=config.MCP_HOST,
+    port=config.MCP_PORT,
+    streamable_http_path=config.MCP_PATH,
+    stateless_http=config.MCP_STATELESS,
+    json_response=config.MCP_JSON_RESPONSE,
 )
 
 # Set up logging with configured level
@@ -101,9 +112,15 @@ tmsearch_client = TmSearchClient()
 tm_assignment_client = TmAssignmentClient()
 
 
-# Register cleanup handler
 async def cleanup():
-    """Clean up resources on shutdown."""
+    """Close every USPTO HTTP client.
+
+    Runs once when the server stops, inside the same event loop the clients
+    were used on. Note this deliberately is *not* wired up as a FastMCP
+    lifespan: in stateless HTTP mode the low-level server — and therefore its
+    lifespan — is entered once per request, which would close these clients
+    after the first tool call.
+    """
     logger.info("Shutting down USPTO Patent MCP server, cleaning up resources...")
     try:
         await ppubs_client.close()
@@ -118,32 +135,6 @@ async def cleanup():
         logger.info("Cleanup completed successfully")
     except Exception as e:
         logger.error(f"Error during cleanup: {str(e)}")
-
-
-# Register cleanup with atexit (best effort for stdio shutdown)
-def sync_cleanup():
-    """Synchronous cleanup wrapper for atexit."""
-    import asyncio
-    try:
-        try:
-            loop = asyncio.get_running_loop()
-            if loop.is_running():
-                loop.create_task(cleanup())
-                return
-        except RuntimeError:
-            pass
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(cleanup())
-        finally:
-            loop.close()
-    except Exception as e:
-        logger.debug(f"Cleanup during shutdown (non-critical): {str(e)}")
-
-
-atexit.register(sync_cleanup)
 
 
 # =====================================================================
@@ -2347,10 +2338,103 @@ async def get_party_litigation(
 # Main entry point
 # =====================================================================
 
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Command-line interface for the server."""
+    parser = argparse.ArgumentParser(
+        prog="patent-mcp-server",
+        description="MCP server for USPTO patent and trademark data.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=sorted(VALID_TRANSPORTS),
+        default=config.MCP_TRANSPORT,
+        help=(
+            "How to serve MCP. 'stdio' (the default) is what Claude Desktop "
+            "and Claude Code launch locally; 'streamable-http' serves a "
+            "network endpoint for shared deployments."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default=config.MCP_HOST,
+        help="Address to bind when serving over HTTP (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=config.MCP_PORT,
+        help="Port to bind when serving over HTTP (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--path",
+        default=config.MCP_PATH,
+        help="URL path for the MCP endpoint (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--stateful",
+        action=argparse.BooleanOptionalAction,
+        default=not config.MCP_STATELESS,
+        help=(
+            "Keep per-client session state between HTTP requests. Off by "
+            "default; enabling it pins each client to one process, so it "
+            "needs session affinity to scale."
+        ),
+    )
+    parser.add_argument(
+        "--json-response",
+        action=argparse.BooleanOptionalAction,
+        default=config.MCP_JSON_RESPONSE,
+        help="Reply with a single JSON response instead of an SSE stream.",
+    )
+    return parser
+
+
+async def serve(transport: str) -> None:
+    """Run the server on ``transport`` and close the HTTP clients afterwards.
+
+    Cleanup lives here rather than in an atexit hook so it runs inside the
+    same event loop the clients were opened on.
+    """
+    try:
+        if transport == "streamable-http":
+            await mcp.run_streamable_http_async()
+        else:
+            await mcp.run_stdio_async()
+    finally:
+        await cleanup()
+
+
 def main():
-    """Initialize and run the server with stdio transport."""
-    logger.info("Starting USPTO Patent & Trademark MCP server with stdio transport")
-    mcp.run(transport='stdio')
+    """Initialize and run the server."""
+    args = build_arg_parser().parse_args()
+
+    # FastMCP reads these when the transport starts, so setting them here
+    # lets the command line override the environment.
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+    mcp.settings.streamable_http_path = args.path
+    mcp.settings.stateless_http = not args.stateful
+    mcp.settings.json_response = args.json_response
+
+    if args.transport == "streamable-http":
+        mode = "stateful" if args.stateful else "stateless"
+        logger.info(
+            f"Starting USPTO Patent & Trademark MCP server on "
+            f"http://{args.host}:{args.port}{args.path} ({mode})"
+        )
+        if args.host not in LOOPBACK_HOSTS:
+            logger.warning(
+                "This endpoint is reachable beyond this machine and performs "
+                "no authentication of its own. It holds your USPTO and TSDR "
+                "API keys — put it behind an authenticating reverse proxy."
+            )
+    else:
+        logger.info("Starting USPTO Patent & Trademark MCP server with stdio transport")
+
+    try:
+        anyio.run(serve, args.transport)
+    except KeyboardInterrupt:
+        logger.info("Server stopped")
 
 
 if __name__ == "__main__":

--- a/src/patent_mcp_server/uspto/ppubs_uspto_gov.py
+++ b/src/patent_mcp_server/uspto/ppubs_uspto_gov.py
@@ -72,6 +72,14 @@ class PpubsClient:
         # Session caching
         self.session_expires_at: Optional[datetime] = None
 
+        # Serializes session establishment. Several tool calls can run
+        # concurrently against this one client (always so over HTTP, and
+        # whenever a client issues parallel tool calls over stdio), and each
+        # of them resetting the cookie jar and swapping the access token at
+        # the same time would leave the others signing requests with a
+        # half-replaced session.
+        self._session_lock = asyncio.Lock()
+
         # Load search query template
         script_dir = Path(__file__).parent.parent
         search_query_path = script_dir / "json" / "search_query.json"
@@ -86,18 +94,58 @@ class PpubsClient:
         """Async context manager exit with cleanup."""
         await self.close()
 
+    def _session_is_cached(self) -> bool:
+        """Whether the cached session is still usable."""
+        if not (config.ENABLE_CACHING and self.session_expires_at):
+            return False
+        return datetime.now() < self.session_expires_at
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Session headers for a single request.
+
+        The token is attached per request rather than stored on the shared
+        client's default headers, so a session refresh cannot retroactively
+        change the credentials of a request that is already in flight.
+        """
+        return {"X-Access-Token": self.access_token} if self.access_token else {}
+
     async def get_session(self) -> Optional[Dict[str, Any]]:
         """Establish a session with USPTO Public Search.
 
-        Uses caching to avoid unnecessary session creation.
+        Uses caching to avoid unnecessary session creation. Concurrent
+        callers share a single establishment rather than each starting their
+        own.
         """
-        # Check if cached session is still valid
-        if config.ENABLE_CACHING and self.session_expires_at:
-            if datetime.now() < self.session_expires_at:
+        if self._session_is_cached():
+            logger.info("Using cached session")
+            return self.session
+
+        async with self._session_lock:
+            # Re-check inside the lock: another caller may have established a
+            # session while we were waiting for it.
+            if self._session_is_cached():
                 logger.info("Using cached session")
                 return self.session
+            return await self._establish_session()
 
+    async def _refresh_session(self, stale_token: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Replace a session that a request found expired.
+
+        ``stale_token`` is the token the failed request actually used. If it
+        no longer matches the current one, another caller has already
+        refreshed and we reuse their session instead of discarding it.
+        """
+        async with self._session_lock:
+            if self.access_token != stale_token:
+                logger.info("Session already refreshed by another request")
+                return self.session
+            return await self._establish_session()
+
+    async def _establish_session(self) -> Optional[Dict[str, Any]]:
+        """Create a new upstream session. Callers must hold ``_session_lock``."""
         logger.info("Establishing new session with USPTO Public Search")
+        # Drop cookies belonging to the dead session before asking for a new
+        # one. Serialized by the lock, so this happens once per refresh.
         self.client.cookies = httpx.Cookies()
 
         try:
@@ -125,7 +173,6 @@ class PpubsClient:
             self.session = response.json()
             self.case_id = self.session["userCase"]["caseId"]
             self.access_token = response.headers["X-Access-Token"]
-            self.client.headers["X-Access-Token"] = self.access_token
 
             # Set session expiration
             if config.ENABLE_CACHING:
@@ -139,6 +186,21 @@ class PpubsClient:
         except Exception as e:
             logger.error(f"Error establishing session: {str(e)}")
             return None
+
+    @staticmethod
+    def _with_auth(kwargs: Dict[str, Any], token: Optional[str]) -> Dict[str, Any]:
+        """Copy request kwargs with the session token added to the headers.
+
+        An explicit ``X-Access-Token`` supplied by the caller wins, which is
+        what lets session creation send its own placeholder token.
+        """
+        if not token:
+            return kwargs
+        merged = dict(kwargs)
+        headers = dict(merged.get("headers") or {})
+        headers.setdefault("X-Access-Token", token)
+        merged["headers"] = headers
+        return merged
 
     @retry(
         stop=stop_after_attempt(config.MAX_RETRIES),
@@ -162,13 +224,20 @@ class PpubsClient:
             httpx.Response object or error dictionary
         """
         try:
-            response = await self.client.request(method, url, **kwargs)
+            # Capture the token this attempt is signed with, so that if it is
+            # rejected we only refresh when nobody else already has.
+            token = self.access_token
+            response = await self.client.request(
+                method, url, **self._with_auth(kwargs, token)
+            )
 
             # Handle 403 (Session expired)
             if response.status_code == 403:
                 logger.info("Session expired, refreshing")
-                await self.get_session()
-                response = await self.client.request(method, url, **kwargs)
+                await self._refresh_session(stale_token=token)
+                response = await self.client.request(
+                    method, url, **self._with_auth(kwargs, self.access_token)
+                )
 
             # Handle rate limiting
             if response.status_code == 429:
@@ -180,7 +249,9 @@ class PpubsClient:
                 ) + 1
                 logger.info(f"Rate limited, waiting {wait_time} seconds")
                 await asyncio.sleep(wait_time)
-                response = await self.client.request(method, url, **kwargs)
+                response = await self.client.request(
+                    method, url, **self._with_auth(kwargs, self.access_token)
+                )
 
             # Log response body for debugging
             logger.debug(f"Response body for {method} {url}: {response.text}")
@@ -193,6 +264,17 @@ class PpubsClient:
         except Exception as e:
             logger.error(f"Request error: {str(e)}")
             return ApiError.from_exception(e, f"Request to {url} failed")
+
+    async def _ensure_case_id(self) -> Optional[str]:
+        """Return the case id of the current session, establishing one if needed.
+
+        Callers should use the returned value rather than re-reading
+        ``self.case_id``, so that a concurrent refresh cannot swap the case id
+        out from under a request that is mid-assembly.
+        """
+        if self.case_id is None:
+            await self.get_session()
+        return self.case_id
 
     async def run_query(
         self,
@@ -225,8 +307,7 @@ class PpubsClient:
             sources = [Sources.PUBLISHED_APPLICATIONS, Sources.GRANTED_PATENTS, Sources.OCR]
 
         # Ensure we have a session
-        if self.case_id is None:
-            await self.get_session()
+        case_id = await self._ensure_case_id()
 
         logger.info(f"Running query: {query}")
 
@@ -236,7 +317,7 @@ class PpubsClient:
         data["start"] = start
         data["pageCount"] = min(limit, Defaults.SEARCH_LIMIT_MAX)
         data["sort"] = sort
-        data["query"]["caseId"] = self.case_id
+        data["query"]["caseId"] = case_id
         data["query"]["op"] = default_operator
         data["query"]["q"] = query
         data["query"]["queryName"] = query
@@ -296,8 +377,7 @@ class PpubsClient:
             Dictionary containing document data or error
         """
         # Ensure we have a session
-        if self.case_id is None:
-            await self.get_session()
+        await self._ensure_case_id()
 
         logger.info(f"Getting document: {guid}")
 
@@ -345,8 +425,7 @@ class PpubsClient:
             Print job ID string or error dictionary
         """
         # Ensure we have a session
-        if self.case_id is None:
-            await self.get_session()
+        case_id = await self._ensure_case_id()
 
         logger.info(f"Requesting PDF save for: {guid}")
 
@@ -358,12 +437,13 @@ class PpubsClient:
         response = await self.client.post(
             f"{config.PPUBS_BASE_URL}/api/print/imageviewer",
             json={
-                "caseId": self.case_id,
+                "caseId": case_id,
                 "pageKeys": page_keys,
                 "patentGuid": guid,
                 "saveOrPrint": "save",
                 "source": document_type,
             },
+            headers=self._auth_headers(),
         )
 
         if response.status_code == 500:
@@ -393,8 +473,7 @@ class PpubsClient:
             Dictionary with PDF content (base64) or error
         """
         # Ensure we have a session
-        if self.case_id is None:
-            await self.get_session()
+        await self._ensure_case_id()
 
         logger.info(f"Downloading document images for: {guid}")
 
@@ -411,6 +490,7 @@ class PpubsClient:
                 response = await self.client.post(
                     f"{config.PPUBS_BASE_URL}/api/print/print-process",
                     json=[print_job_id],
+                    headers=self._auth_headers(),
                 )
 
                 if response.status_code != 200:
@@ -434,6 +514,7 @@ class PpubsClient:
             request = self.client.build_request(
                 HTTPMethods.GET,
                 f"{config.PPUBS_BASE_URL}/api/internal/print/save/{pdf_name}",
+                headers=self._auth_headers(),
             )
 
             response = await self.client.send(request, stream=True)

--- a/test/unit/test_mcp_server.py
+++ b/test/unit/test_mcp_server.py
@@ -1,0 +1,230 @@
+"""Unit tests for the MCP protocol layer.
+
+The rest of the suite calls the tool functions directly, which skips
+everything FastMCP does: schema generation, resource and prompt
+registration, and serialization of results. These tests drive the server
+through a real ClientSession over an in-memory transport, so a change that
+breaks registration or a tool signature fails here rather than in a user's
+client.
+"""
+import json
+
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from patent_mcp_server import patents
+
+
+def connect():
+    """Open a client session against the real server object.
+
+    Used inline as ``async with connect() as session``. Deliberately not a
+    pytest fixture: the session holds a running server task for as long as
+    it is open, and handing that across a fixture yield deadlocks when the
+    fixture and the test resolve to different event loops.
+    """
+    return create_connected_server_and_client_session(patents.mcp)
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_server_exposes_tools():
+    """The full tool set is registered and reachable over the protocol."""
+    async with connect() as session:
+        result = await session.list_tools()
+        names = {tool.name for tool in result.tools}
+
+        # Spot-check one tool per active API family
+        assert "ppubs_search_patents" in names
+        assert "odp_get_application" in names
+        assert "ptab_search_proceedings" in names
+        assert "tsdr_get_trademark_status" in names
+        assert "tm_search_trademarks" in names
+        assert "check_api_status" in names
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_every_tool_has_usable_schema():
+    """Each tool carries a description and an object input schema.
+
+    FastMCP builds these from the function signature and docstring, so this
+    catches an unannotated argument or a missing docstring.
+    """
+    async with connect() as session:
+        result = await session.list_tools()
+
+        for tool in result.tools:
+            assert tool.description, f"{tool.name} has no description"
+            assert tool.inputSchema["type"] == "object", f"{tool.name} schema is not an object"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_server_exposes_prompts():
+    """Workflow prompts are registered."""
+    async with connect() as session:
+        result = await session.list_prompts()
+        assert len(result.prompts) > 0
+        for prompt in result.prompts:
+            assert prompt.name
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_server_exposes_resources():
+    """Static reference resources are registered."""
+    async with connect() as session:
+        result = await session.list_resources()
+        uris = {str(resource.uri) for resource in result.resources}
+        assert "patents://sources" in uris
+
+
+# ============================================================================
+# Round trips
+# ============================================================================
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_call_tool_returns_json():
+    """A tool call travels through the protocol and returns usable JSON.
+
+    get_cpc_info is served from local reference data, so this needs no
+    network access.
+    """
+    async with connect() as session:
+        result = await session.call_tool("get_cpc_info", {"cpc_code": "G06"})
+
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "G06"
+        assert payload["section"] == "G"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_read_resource():
+    """Resources can be read over the protocol."""
+    async with connect() as session:
+        result = await session.read_resource("patents://sources")
+        assert result.contents[0].text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_prompt():
+    """Prompts render over the protocol."""
+    async with connect() as session:
+        prompts = await session.list_prompts()
+        result = await session.get_prompt(prompts.prompts[0].name, {})
+        assert result.messages
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_decommissioned_tool_reports_unavailable():
+    """A shut-down API surfaces its guidance through the protocol.
+
+    These tools stay registered on purpose so clients get a workaround
+    instead of an unknown-tool error.
+    """
+    async with connect() as session:
+        result = await session.call_tool("patentsview_search_patents", {"query": "test"})
+
+        payload = json.loads(result.content[0].text)
+        assert payload["error"] is True
+        assert payload["error_code"] == "API_UNAVAILABLE"
+        assert payload["workaround"]
+
+
+# ============================================================================
+# Statelessness
+# ============================================================================
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_server_survives_repeated_sessions():
+    """Consecutive sessions each work against the same server object.
+
+    In stateless HTTP mode the low-level server is entered once per request,
+    so anything torn down at the end of a session would leave later requests
+    broken. This is the regression test for putting client shutdown in a
+    lifespan.
+    """
+    for _ in range(3):
+        async with create_connected_server_and_client_session(patents.mcp) as client:
+            result = await client.call_tool("get_cpc_info", {"cpc_code": "G06"})
+            assert not result.isError
+
+    # The shared HTTP clients must still be open for real work to continue.
+    assert not patents.ppubs_client.client.is_closed
+    assert not patents.api_client.client.is_closed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_sessions_are_independent():
+    """Two sessions can run at once without sharing protocol state."""
+    import anyio
+
+    results = {}
+
+    async def run(label):
+        async with create_connected_server_and_client_session(patents.mcp) as client:
+            result = await client.call_tool("get_cpc_info", {"cpc_code": "G06"})
+            results[label] = json.loads(result.content[0].text)["code"]
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(run, "a")
+        tg.start_soon(run, "b")
+
+    assert results == {"a": "G06", "b": "G06"}
+
+
+# ============================================================================
+# Transport configuration
+# ============================================================================
+
+@pytest.mark.unit
+def test_default_transport_is_stdio():
+    """Existing local installs keep working without new flags."""
+    args = patents.build_arg_parser().parse_args([])
+    assert args.transport == "stdio"
+
+
+@pytest.mark.unit
+def test_http_transport_flags():
+    """HTTP options are wired through to the parser."""
+    args = patents.build_arg_parser().parse_args(
+        ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9001"]
+    )
+    assert args.transport == "streamable-http"
+    assert args.host == "0.0.0.0"
+    assert args.port == 9001
+
+
+@pytest.mark.unit
+def test_env_var_sets_statelessness(monkeypatch):
+    """MCP_STATELESS is honoured, and the command line can still override it.
+
+    build_arg_parser() reads the config when it is called, so the flag
+    default tracks the environment rather than being fixed at import.
+    """
+    monkeypatch.setattr(patents.config, "MCP_STATELESS", False)
+    assert patents.build_arg_parser().parse_args([]).stateful is True
+    assert patents.build_arg_parser().parse_args(["--no-stateful"]).stateful is False
+
+    monkeypatch.setattr(patents.config, "MCP_STATELESS", True)
+    assert patents.build_arg_parser().parse_args([]).stateful is False
+    assert patents.build_arg_parser().parse_args(["--stateful"]).stateful is True
+
+
+@pytest.mark.unit
+def test_stateless_is_the_default():
+    """HTTP serving is stateless unless --stateful is passed."""
+    assert patents.build_arg_parser().parse_args([]).stateful is False
+    assert patents.build_arg_parser().parse_args(["--stateful"]).stateful is True

--- a/test/unit/test_ppubs_client.py
+++ b/test/unit/test_ppubs_client.py
@@ -197,7 +197,7 @@ async def test_make_request_success(ppubs_client):
 async def test_make_request_session_expired_refresh(ppubs_client, mock_session_data):
     """Test automatic session refresh on 403 error."""
     with patch.object(ppubs_client.client, 'request', new_callable=AsyncMock) as mock_request:
-        with patch.object(ppubs_client, 'get_session', new_callable=AsyncMock) as mock_get_session:
+        with patch.object(ppubs_client, '_refresh_session', new_callable=AsyncMock) as mock_refresh:
             # First response: 403 (session expired)
             expired_response = MagicMock()
             expired_response.status_code = 403
@@ -209,12 +209,13 @@ async def test_make_request_session_expired_refresh(ppubs_client, mock_session_d
             success_response.text = '{"result": "success"}'
 
             mock_request.side_effect = [expired_response, success_response]
-            mock_get_session.return_value = mock_session_data
+            mock_refresh.return_value = mock_session_data
 
             response = await ppubs_client.make_request("GET", "http://test.com")
 
-            # Should have refreshed session
-            mock_get_session.assert_called_once()
+            # Should have refreshed session, passing the token that was rejected
+            # so a concurrent refresh isn't duplicated
+            mock_refresh.assert_called_once_with(stale_token=None)
 
             # Should have retried request
             assert mock_request.call_count == 2
@@ -548,3 +549,117 @@ async def test_ppubs_download_patent_pdf_tool_passes_full_signature():
         patent_doc["pageCount"],
         patent_doc["type"],
     )
+
+
+# ============================================================================
+# Session Concurrency Tests
+# ============================================================================
+
+def _session_post_mock(mock_session_data):
+    """A POST mock that answers session-creation requests."""
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = mock_session_data
+    response.headers = {"X-Access-Token": "test-token-123"}
+    response.text = json.dumps(mock_session_data)
+    return response
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_get_session_establishes_once(ppubs_client, mock_session_data):
+    """Parallel callers share one session instead of each creating their own.
+
+    Without the lock every concurrent tool call resets the cookie jar and
+    races to swap the access token, so the requests that are already in
+    flight end up signed with a half-replaced session.
+    """
+    async def slow_get(*args, **kwargs):
+        # A real suspension point, so the other callers get a chance to run
+        # mid-establishment. Without it the mocks never yield and the
+        # coroutines run one after another, which would hide the race.
+        await asyncio.sleep(0.01)
+        return MagicMock(status_code=200)
+
+    async def slow_post(*args, **kwargs):
+        await asyncio.sleep(0.01)
+        return _session_post_mock(mock_session_data)
+
+    with patch.object(ppubs_client.client, 'get', side_effect=slow_get):
+        with patch.object(ppubs_client.client, 'post', side_effect=slow_post) as mock_post:
+            results = await asyncio.gather(*(ppubs_client.get_session() for _ in range(5)))
+
+            # One establishment, and everyone got the same session back.
+            assert mock_post.call_count == 1
+            assert all(r == mock_session_data for r in results)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_refresh_skipped_when_another_caller_already_refreshed(
+    ppubs_client, mock_session_data
+):
+    """A 403 does not discard a session that someone else just replaced."""
+    ppubs_client.session = mock_session_data
+    ppubs_client.access_token = "current-token"
+
+    with patch.object(ppubs_client.client, 'post', new_callable=AsyncMock) as mock_post:
+        # The caller's request was signed with a token that has since been
+        # superseded, so there is nothing left to refresh.
+        result = await ppubs_client._refresh_session(stale_token="already-replaced")
+
+        mock_post.assert_not_called()
+        assert result == mock_session_data
+        assert ppubs_client.access_token == "current-token"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_refresh_proceeds_when_token_is_still_current(ppubs_client, mock_session_data):
+    """A 403 on the newest token does establish a replacement session."""
+    ppubs_client.access_token = "stale-token"
+
+    with patch.object(ppubs_client.client, 'get', new_callable=AsyncMock) as mock_get:
+        with patch.object(ppubs_client.client, 'post', new_callable=AsyncMock) as mock_post:
+            mock_get.return_value = MagicMock(status_code=200)
+            mock_post.return_value = _session_post_mock(mock_session_data)
+
+            await ppubs_client._refresh_session(stale_token="stale-token")
+
+            assert ppubs_client.access_token == "test-token-123"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_token_is_sent_per_request(ppubs_client):
+    """The session token rides on each request, not on the shared client.
+
+    Keeping it off the client's default headers means a refresh cannot
+    change the credentials of a request that has already been built.
+    """
+    ppubs_client.access_token = "test-token-123"
+
+    with patch.object(ppubs_client.client, 'request', new_callable=AsyncMock) as mock_request:
+        mock_request.return_value = MagicMock(status_code=200, text="{}")
+
+        await ppubs_client.make_request("GET", "http://test.com")
+
+        sent = mock_request.call_args.kwargs["headers"]
+        assert sent["X-Access-Token"] == "test-token-123"
+        assert "X-Access-Token" not in ppubs_client.client.headers
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_caller_supplied_token_is_preserved(ppubs_client):
+    """An explicit token wins, so session creation can send its placeholder."""
+    ppubs_client.access_token = "test-token-123"
+
+    with patch.object(ppubs_client.client, 'request', new_callable=AsyncMock) as mock_request:
+        mock_request.return_value = MagicMock(status_code=200, text="{}")
+
+        await ppubs_client.make_request(
+            "POST", "http://test.com", headers={"X-Access-Token": "null"}
+        )
+
+        assert mock_request.call_args.kwargs["headers"]["X-Access-Token"] == "null"

--- a/uv.lock
+++ b/uv.lock
@@ -813,7 +813,7 @@ wheels = [
 
 [[package]]
 name = "patent-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "h2" },
@@ -848,7 +848,7 @@ dev = [
 requires-dist = [
     { name = "h2", specifier = ">=4.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.3.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

Adds a streamable-HTTP transport so the server can run as a shared, stateless service instead of only as a per-user local process, and fixes a session race in the Public Search client that affects existing stdio users too. `stdio` remains the default, so every existing Claude Desktop and Claude Code configuration keeps working unchanged.

```shell
patent-mcp-server --transport streamable-http --host 0.0.0.0 --port 8000
```

Four things changed:

1. **Streamable-HTTP transport, stateless by default.** New `--transport`, `--host`, `--port`, `--path`, `--stateful/--no-stateful`, `--json-response/--no-json-response` flags, each with a matching `MCP_*` environment variable that the command line overrides. Stateless mode keeps no per-client state between requests, so the server can sit behind a load balancer with several replicas and no session affinity; each worker holds its own upstream USPTO session.

2. **Fixed a session race in `PpubsClient`.** Concurrent tool calls each reset the shared cookie jar and raced to swap the access token, so a request already in flight could be signed with a half-replaced session. Session setup is now serialized behind a lock with a double-check, a 403 refresh is skipped when another call has already replaced the token, and the token travels per request instead of living on the shared client's default headers. This is a real fix for stdio users too, not just an HTTP prerequisite.

3. **Fixed shutdown.** Closing the nine HTTP clients ran in an `atexit` hook that spun up a fresh event loop. It now runs in the loop the clients were opened on.

4. **Raised the MCP SDK floor to `>=1.27`.** The previous `>=1.3.0` allowed an install without the lock to resolve an SDK with no streamable-HTTP support.

### One design note worth a reviewer's attention

Shutdown is deliberately **not** a FastMCP `lifespan`. In stateless mode `StreamableHTTPSessionManager` calls `app.run()` once *per request*, and `Server.run()` enters the lifespan — so a lifespan would close all nine HTTP clients after the first tool call and break every request after it. `test_server_survives_repeated_sessions` pins this, and the trap is written up in `CLAUDE.md` so it doesn't get reintroduced.

### Security posture of the HTTP endpoint

The endpoint performs no authentication of its own and holds the operator's USPTO and TSDR API keys. It binds to `127.0.0.1` by default, logs a warning when bound anywhere else, and the README calls for an authenticating reverse proxy in front. I did not add a bespoke token scheme — that belongs to the deployment layer, and a half-measure would invite misplaced trust. Happy to revisit if you'd prefer something built in.

## Linked issue

No tracking issue — the repository has no open issues. Filing one first if you'd prefer the history is easy to do.

## Test plan

- [x] `uv run pytest` passes — **378 passed, 54 deselected** (up from 359)
- [x] New behavior is covered by a new unit test — 19 new tests
- [ ] Tested manually against the live USPTO API — **not possible from this environment; see below**

**What was verified.** Both transports were driven end-to-end with a real MCP client: stdio via `stdio_client` and HTTP via `streamablehttp_client`, each listing 61 tools and 9 prompts and completing a live tool call. Three independent HTTP connections, two of them concurrent and none carrying a session ID, all succeeded — confirming statelessness in practice rather than just in configuration. Clean shutdown was confirmed from the server log with all nine clients closed in-loop.

The new concurrency test was checked against a deliberately un-locked build to confirm it can actually fail: **1** session establishment with the lock, **5** without. (My first version of that test passed even without the lock, because the `AsyncMock`s never suspended and the coroutines ran to completion one at a time; it now forces real interleaving.)

**What was not verified, and what I'd ask a reviewer to check.** The sandbox this ran in blocks egress to `ppubs.uspto.gov`, so no request reached the live USPTO. The change most deserving of a live check is the `X-Access-Token` move from the shared client's default headers to per-request headers, which touches `ppubs_search_patents`, `ppubs_get_patent`, and `ppubs_download_patent_pdf` — the PDF path especially, since `_request_save`, the print-status poll, and the streamed download each now pass the header explicitly. It is behavior-preserving in principle and covered by unit tests, but a single real patent search plus one PDF download would confirm it. One incidental signal: the proxy's own 403 exercised the refresh path correctly, retrying without looping and returning a proper error dict.

## Checklist

- [x] Docstrings updated — new/changed functions documented; no tool signatures or `USE THIS TOOL WHEN:` guidance changed, so tool docstrings are untouched
- [x] Version bumped in `pyproject.toml` AND `src/patent_mcp_server/config.py` (`USER_AGENT`) — both at 1.1.0, plus the `patents.py` docstring
- [x] Not touching a decommissioned API — no change to the 25 unavailable tools
- [x] No new dependencies — `anyio` and `argparse` are already available (`anyio` transitively via the MCP SDK, `argparse` is stdlib)

---
_Generated by [Claude Code](https://claude.ai/code/session_0152T4x8geBk2LZqtXRUCkUy)_