### PR TITLE
Update uv.lock for 1.1.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -419,7 +419,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "patent-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "h2" },


### PR DESCRIPTION
Regenerates the lock so its own-package entry matches the 1.1.1 bump merged in #35 (plus a `typing-extensions` marker refinement from the current uv resolver). No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)